### PR TITLE
chore: drop support for 32-bit musllinux

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,15 +42,6 @@ jobs:
             artifact_name: "wheels-ubuntu-latest-musllinux-x64"
 
           # ----------------------------------------------------
-          # musllinux 32-bit
-          # ----------------------------------------------------
-          - os: ubuntu-latest
-            build_type: musllinux-x86
-            cibw_build: "*musllinux*"
-            cibw_archs_linux: i686
-            artifact_name: "wheels-ubuntu-latest-musllinux-x86"
-
-          # ----------------------------------------------------
           # macOS (64-bit only)
           # ----------------------------------------------------
           - os: macos-latest


### PR DESCRIPTION
### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
