### PR TITLE
fix: loosen cchecksum pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
 	"wheel",
 	"mypy[mypyc]>=1.14.1,<1.17.1",
 	"mypy_extensions",
-	"cchecksum>=0.3.1,<0.4",
+	"cchecksum>=0.2.6,<0.4",
 	"faster-eth-utils>=2.0.0",
 	"eth-typing>=3.0.0",
 	"parsimonious>=0.10.0,<0.11.0",

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     url="https://github.com/BobTheBuidler/faster-eth-abi",
     include_package_data=True,
     install_requires=[
-        "cchecksum>=0.3.1,<0.4",
+        "cchecksum>=0.2.6,<0.4",
         "faster-eth-utils>=2.0.0",
         "eth-typing>=3.0.0",
         "mypy_extensions",


### PR DESCRIPTION
currently cannot install with brownie 1.21.0

this PR fixes that

### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
