### PR TITLE
fix: conflict with downstream dank-mids

### DIFF
--- a/faster_eth_abi/encoding.py
+++ b/faster_eth_abi/encoding.py
@@ -668,5 +668,3 @@ class DynamicArrayEncoder(BaseArrayEncoder):
 
     def encode(self, value: Sequence[Any]) -> bytes:
         return encode_elements_dynamic(self.item_encoder, value)
-
-    __call__ = encode


### PR DESCRIPTION
I have a monkey patch in there that breaks with one of the latest optimizations, so I'll undo it in one case.

### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/faster-eth-abi/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
