### PR TITLE
Revert "feat: microoptimize utils/numeric.py functions (#55)"

### DIFF
--- a/build/__native_76f9a3652d4d2667c55c.c
+++ b/build/__native_76f9a3652d4d2667c55c.c
@@ -363,7 +363,7 @@ char CPyDef__codec_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[236]; /* ('TYPE_CHECKING', 'Any', 'Iterable', 'Tuple') */
+    cpy_r_r5 = CPyStatics[235]; /* ('TYPE_CHECKING', 'Any', 'Iterable', 'Tuple') */
     cpy_r_r6 = CPyStatics[16]; /* 'typing' */
     cpy_r_r7 = CPyStatic__codec___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
@@ -374,7 +374,7 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r8;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r8);
-    cpy_r_r9 = CPyStatics[237]; /* ('Decodable', 'TypeStr') */
+    cpy_r_r9 = CPyStatics[236]; /* ('Decodable', 'TypeStr') */
     cpy_r_r10 = CPyStatics[19]; /* 'eth_typing' */
     cpy_r_r11 = CPyStatic__codec___globals;
     cpy_r_r12 = CPyImport_ImportFromMany(cpy_r_r10, cpy_r_r9, cpy_r_r9, cpy_r_r11);
@@ -385,7 +385,7 @@ CPyL3: ;
     CPyModule_eth_typing = cpy_r_r12;
     CPy_INCREF(CPyModule_eth_typing);
     CPy_DECREF(cpy_r_r12);
-    cpy_r_r13 = CPyStatics[238]; /* ('validate_bytes_param', 'validate_list_like_param') */
+    cpy_r_r13 = CPyStatics[237]; /* ('validate_bytes_param', 'validate_list_like_param') */
     cpy_r_r14 = CPyStatics[22]; /* 'faster_eth_abi.utils.validation' */
     cpy_r_r15 = CPyStatic__codec___globals;
     cpy_r_r16 = CPyImport_ImportFromMany(cpy_r_r14, cpy_r_r13, cpy_r_r13, cpy_r_r15);
@@ -489,7 +489,7 @@ CPyTagged CPyDef__decoding___decode_uint_256(PyObject *cpy_r_stream) {
     PyObject *cpy_r_r29;
     CPyTagged cpy_r_r30;
     cpy_r_r0 = CPyStatics[23]; /* 'read' */
-    cpy_r_r1 = CPyStatics[224]; /* 32 */
+    cpy_r_r1 = CPyStatics[223]; /* 32 */
     PyObject *cpy_r_r2[2] = {cpy_r_stream, cpy_r_r1};
     cpy_r_r3 = (PyObject **)&cpy_r_r2;
     cpy_r_r4 = PyObject_VectorcallMethod(cpy_r_r0, cpy_r_r3, 9223372036854775810ULL, 0);
@@ -1166,7 +1166,7 @@ PyObject *CPyDef__decoding___decode_dynamic_array(PyObject *cpy_r_self, PyObject
         goto CPyL35;
     }
     cpy_r_r1 = CPyStatics[29]; /* 'push_frame' */
-    cpy_r_r2 = CPyStatics[224]; /* 32 */
+    cpy_r_r2 = CPyStatics[223]; /* 32 */
     PyObject *cpy_r_r3[2] = {cpy_r_stream, cpy_r_r2};
     cpy_r_r4 = (PyObject **)&cpy_r_r3;
     cpy_r_r5 = PyObject_VectorcallMethod(cpy_r_r1, cpy_r_r4, 9223372036854775810ULL, 0);
@@ -1636,7 +1636,7 @@ CPyL6: ;
     } else
         goto CPyL8;
 CPyL7: ;
-    cpy_r_r9 = CPyStatics[220]; /* b'' */
+    cpy_r_r9 = CPyStatics[219]; /* b'' */
     CPy_INCREF(cpy_r_raw_data);
     CPy_INCREF(cpy_r_r9);
     cpy_r_r10.f0 = cpy_r_raw_data;
@@ -1795,7 +1795,7 @@ char CPyDef__decoding___validate_padding_bytes_fixed_byte_size(PyObject *cpy_r_s
     cpy_r_r4 = CPyTagged_Subtract(cpy_r_r3, cpy_r_r0);
     CPyTagged_DECREF(cpy_r_r3);
     CPyTagged_DECREF(cpy_r_r0);
-    cpy_r_r5 = CPyStatics[221]; /* b'\x00' */
+    cpy_r_r5 = CPyStatics[220]; /* b'\x00' */
     cpy_r_r6 = CPyTagged_StealAsObject(cpy_r_r4);
     cpy_r_r7 = PyNumber_Multiply(cpy_r_r5, cpy_r_r6);
     CPy_DECREF(cpy_r_r6);
@@ -1950,7 +1950,7 @@ char CPyDef__decoding___decoder_fn_boolean(PyObject *cpy_r_data) {
     PyObject **cpy_r_r26;
     PyObject *cpy_r_r27;
     char cpy_r_r28;
-    cpy_r_r0 = CPyStatics[221]; /* b'\x00' */
+    cpy_r_r0 = CPyStatics[220]; /* b'\x00' */
     cpy_r_r1 = CPyBytes_Compare(cpy_r_data, cpy_r_r0);
     cpy_r_r2 = cpy_r_r1 >= 0;
     if (unlikely(!cpy_r_r2)) {
@@ -1961,7 +1961,7 @@ char CPyDef__decoding___decoder_fn_boolean(PyObject *cpy_r_data) {
     if (!cpy_r_r3) goto CPyL3;
     return 0;
 CPyL3: ;
-    cpy_r_r4 = CPyStatics[222]; /* b'\x01' */
+    cpy_r_r4 = CPyStatics[221]; /* b'\x01' */
     cpy_r_r5 = CPyBytes_Compare(cpy_r_data, cpy_r_r4);
     cpy_r_r6 = cpy_r_r5 >= 0;
     if (unlikely(!cpy_r_r6)) {
@@ -2104,7 +2104,7 @@ char CPyDef__decoding_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[239]; /* ('TYPE_CHECKING', 'Any', 'Tuple') */
+    cpy_r_r5 = CPyStatics[238]; /* ('TYPE_CHECKING', 'Any', 'Tuple') */
     cpy_r_r6 = CPyStatics[16]; /* 'typing' */
     cpy_r_r7 = CPyStatic__decoding___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
@@ -2115,7 +2115,7 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r8;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r8);
-    cpy_r_r9 = CPyStatics[240]; /* ('big_endian_to_int',) */
+    cpy_r_r9 = CPyStatics[239]; /* ('big_endian_to_int',) */
     cpy_r_r10 = CPyStatics[49]; /* 'faster_eth_utils' */
     cpy_r_r11 = CPyStatic__decoding___globals;
     cpy_r_r12 = CPyImport_ImportFromMany(cpy_r_r10, cpy_r_r9, cpy_r_r9, cpy_r_r11);
@@ -2126,7 +2126,7 @@ CPyL3: ;
     CPyModule_faster_eth_utils = cpy_r_r12;
     CPy_INCREF(CPyModule_faster_eth_utils);
     CPy_DECREF(cpy_r_r12);
-    cpy_r_r13 = CPyStatics[241]; /* ('InsufficientDataBytes', 'NonEmptyPaddingBytes') */
+    cpy_r_r13 = CPyStatics[240]; /* ('InsufficientDataBytes', 'NonEmptyPaddingBytes') */
     cpy_r_r14 = CPyStatics[50]; /* 'faster_eth_abi.exceptions' */
     cpy_r_r15 = CPyStatic__decoding___globals;
     cpy_r_r16 = CPyImport_ImportFromMany(cpy_r_r14, cpy_r_r13, cpy_r_r13, cpy_r_r15);
@@ -2137,7 +2137,7 @@ CPyL3: ;
     CPyModule_faster_eth_abi___exceptions = cpy_r_r16;
     CPy_INCREF(CPyModule_faster_eth_abi___exceptions);
     CPy_DECREF(cpy_r_r16);
-    cpy_r_r17 = CPyStatics[242]; /* ('BytesIO', 'ContextFramesBytesIO') */
+    cpy_r_r17 = CPyStatics[241]; /* ('BytesIO', 'ContextFramesBytesIO') */
     cpy_r_r18 = CPyStatics[53]; /* 'faster_eth_abi.io' */
     cpy_r_r19 = CPyStatic__decoding___globals;
     cpy_r_r20 = CPyImport_ImportFromMany(cpy_r_r18, cpy_r_r17, cpy_r_r17, cpy_r_r19);
@@ -2417,7 +2417,7 @@ CPyL13: ;
         CPy_AddTraceback("faster_eth_abi/_encoding.py", "encode_tuple", 31, CPyStatic__encoding___globals);
         goto CPyL62;
     }
-    cpy_r_r27 = CPyStatics[220]; /* b'' */
+    cpy_r_r27 = CPyStatics[219]; /* b'' */
     cpy_r_r28 = PyList_Append(cpy_r_r1, cpy_r_r27);
     cpy_r_r29 = cpy_r_r28 >= 0;
     if (unlikely(!cpy_r_r29)) {
@@ -2500,7 +2500,7 @@ CPyL28: ;
         CPy_AddTraceback("faster_eth_abi/_encoding.py", "encode_tuple", 35, CPyStatic__encoding___globals);
         goto CPyL65;
     }
-    cpy_r_r53 = CPyStatics[225]; /* 0 */
+    cpy_r_r53 = CPyStatics[224]; /* 0 */
     cpy_r_r54 = (CPyPtr)&((PyListObject *)cpy_r_r52)->ob_item;
     cpy_r_r55 = *(CPyPtr *)cpy_r_r54;
     *(PyObject * *)cpy_r_r55 = cpy_r_r53;
@@ -2652,14 +2652,14 @@ CPyL49: ;
         CPy_AddTraceback("faster_eth_abi/_encoding.py", "encode_tuple", 41, CPyStatic__encoding___globals);
         goto CPyL75;
     }
-    cpy_r_r108 = CPyStatics[220]; /* b'' */
+    cpy_r_r108 = CPyStatics[219]; /* b'' */
     cpy_r_r109 = CPyBytes_Join(cpy_r_r108, cpy_r_r107);
     CPy_DECREF(cpy_r_r107);
     if (unlikely(cpy_r_r109 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/_encoding.py", "encode_tuple", 46, CPyStatic__encoding___globals);
         goto CPyL75;
     }
-    cpy_r_r110 = CPyStatics[220]; /* b'' */
+    cpy_r_r110 = CPyStatics[219]; /* b'' */
     cpy_r_r111 = CPyBytes_Join(cpy_r_r110, cpy_r_r1);
     CPy_DECREF_NO_IMM(cpy_r_r1);
     if (unlikely(cpy_r_r111 == NULL)) {
@@ -2838,7 +2838,7 @@ PyObject *CPyDef__encoding___encode_fixed(PyObject *cpy_r_value, PyObject *cpy_r
         goto CPyL9;
     }
     if (!cpy_r_is_big_endian) goto CPyL6;
-    cpy_r_r4 = CPyStatics[221]; /* b'\x00' */
+    cpy_r_r4 = CPyStatics[220]; /* b'\x00' */
     cpy_r_r5 = CPyStatics[55]; /* 'rjust' */
     CPyTagged_INCREF(cpy_r_data_byte_size);
     cpy_r_r6 = CPyTagged_StealAsObject(cpy_r_data_byte_size);
@@ -2859,7 +2859,7 @@ PyObject *CPyDef__encoding___encode_fixed(PyObject *cpy_r_value, PyObject *cpy_r
     }
     return cpy_r_r10;
 CPyL6: ;
-    cpy_r_r11 = CPyStatics[221]; /* b'\x00' */
+    cpy_r_r11 = CPyStatics[220]; /* b'\x00' */
     cpy_r_r12 = CPyStatics[56]; /* 'ljust' */
     CPyTagged_INCREF(cpy_r_data_byte_size);
     cpy_r_r13 = CPyTagged_StealAsObject(cpy_r_data_byte_size);
@@ -2955,7 +2955,7 @@ PyObject *CPyDef__encoding___encode_signed(PyObject *cpy_r_value, PyObject *cpy_
         CPy_TypeErrorTraceback("faster_eth_abi/_encoding.py", "encode_signed", 67, CPyStatic__encoding___globals, "bytes", cpy_r_r2);
         goto CPyL11;
     }
-    cpy_r_r4 = CPyStatics[225]; /* 0 */
+    cpy_r_r4 = CPyStatics[224]; /* 0 */
     cpy_r_r5 = PyObject_RichCompare(cpy_r_value, cpy_r_r4, 5);
     if (unlikely(cpy_r_r5 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/_encoding.py", "encode_signed", 68, CPyStatic__encoding___globals);
@@ -2971,7 +2971,7 @@ PyObject *CPyDef__encoding___encode_signed(PyObject *cpy_r_value, PyObject *cpy_
         goto CPyL12;
     }
     if (!cpy_r_r6) goto CPyL8;
-    cpy_r_r7 = CPyStatics[221]; /* b'\x00' */
+    cpy_r_r7 = CPyStatics[220]; /* b'\x00' */
     cpy_r_r8 = CPyStatics[55]; /* 'rjust' */
     CPyTagged_INCREF(cpy_r_data_byte_size);
     cpy_r_r9 = CPyTagged_StealAsObject(cpy_r_data_byte_size);
@@ -2992,7 +2992,7 @@ PyObject *CPyDef__encoding___encode_signed(PyObject *cpy_r_value, PyObject *cpy_
     }
     return cpy_r_r13;
 CPyL8: ;
-    cpy_r_r14 = CPyStatics[223]; /* b'\xff' */
+    cpy_r_r14 = CPyStatics[222]; /* b'\xff' */
     cpy_r_r15 = CPyStatics[55]; /* 'rjust' */
     CPyTagged_INCREF(cpy_r_data_byte_size);
     cpy_r_r16 = CPyTagged_StealAsObject(cpy_r_data_byte_size);
@@ -3189,7 +3189,7 @@ CPyL6: ;
     CPyTagged_DECREF(cpy_r_r15);
     if (!cpy_r_r16) goto CPyL15;
 CPyL13: ;
-    cpy_r_r17 = CPyStatics[220]; /* b'' */
+    cpy_r_r17 = CPyStatics[219]; /* b'' */
     cpy_r_r18 = CPyBytes_Join(cpy_r_r17, cpy_r_r10);
     CPy_DECREF(cpy_r_r10);
     if (unlikely(cpy_r_r18 == NULL)) {
@@ -3210,7 +3210,7 @@ CPyL15: ;
         CPy_AddTraceback("faster_eth_abi/_encoding.py", "encode_elements", 82, CPyStatic__encoding___globals);
         goto CPyL41;
     }
-    cpy_r_r22 = CPyStatics[225]; /* 0 */
+    cpy_r_r22 = CPyStatics[224]; /* 0 */
     cpy_r_r23 = (CPyPtr)&((PyListObject *)cpy_r_r21)->ob_item;
     cpy_r_r24 = *(CPyPtr *)cpy_r_r23;
     *(PyObject * *)cpy_r_r24 = cpy_r_r22;
@@ -3301,14 +3301,14 @@ CPyL26: ;
     cpy_r_r44 = cpy_r_r56;
     goto CPyL26;
 CPyL31: ;
-    cpy_r_r57 = CPyStatics[220]; /* b'' */
+    cpy_r_r57 = CPyStatics[219]; /* b'' */
     cpy_r_r58 = CPyBytes_Join(cpy_r_r57, cpy_r_r43);
     CPy_DECREF(cpy_r_r43);
     if (unlikely(cpy_r_r58 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/_encoding.py", "encode_elements", 91, CPyStatic__encoding___globals);
         goto CPyL40;
     }
-    cpy_r_r59 = CPyStatics[220]; /* b'' */
+    cpy_r_r59 = CPyStatics[219]; /* b'' */
     cpy_r_r60 = CPyBytes_Join(cpy_r_r59, cpy_r_r10);
     CPy_DECREF(cpy_r_r10);
     if (unlikely(cpy_r_r60 == NULL)) {
@@ -3469,9 +3469,9 @@ PyObject *CPyDef__encoding___encode_uint_256(CPyTagged cpy_r_i) {
         CPy_AddTraceback("faster_eth_abi/_encoding.py", "encode_uint_256", 104, CPyStatic__encoding___globals);
         goto CPyL4;
     }
-    cpy_r_r1 = CPyStatics[221]; /* b'\x00' */
+    cpy_r_r1 = CPyStatics[220]; /* b'\x00' */
     cpy_r_r2 = CPyStatics[55]; /* 'rjust' */
-    cpy_r_r3 = CPyStatics[224]; /* 32 */
+    cpy_r_r3 = CPyStatics[223]; /* 32 */
     PyObject *cpy_r_r4[3] = {cpy_r_r0, cpy_r_r3, cpy_r_r1};
     cpy_r_r5 = (PyObject **)&cpy_r_r4;
     cpy_r_r6 = PyObject_VectorcallMethod(cpy_r_r2, cpy_r_r5, 9223372036854775811ULL, 0);
@@ -3660,7 +3660,7 @@ char CPyDef__encoding_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[243]; /* ('TYPE_CHECKING', 'Any', 'Callable', 'List', 'Optional',
+    cpy_r_r5 = CPyStatics[242]; /* ('TYPE_CHECKING', 'Any', 'Callable', 'List', 'Optional',
                                    'Sequence', 'TypeVar') */
     cpy_r_r6 = CPyStatics[16]; /* 'typing' */
     cpy_r_r7 = CPyStatic__encoding___globals;
@@ -3837,7 +3837,7 @@ char CPyDef_abi_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[244]; /* ('Final',) */
+    cpy_r_r5 = CPyStatics[243]; /* ('Final',) */
     cpy_r_r6 = CPyStatics[16]; /* 'typing' */
     cpy_r_r7 = CPyStatic_abi___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
@@ -3848,7 +3848,7 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r8;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r8);
-    cpy_r_r9 = CPyStatics[245]; /* ('ABICodec',) */
+    cpy_r_r9 = CPyStatics[244]; /* ('ABICodec',) */
     cpy_r_r10 = CPyStatics[68]; /* 'faster_eth_abi.codec' */
     cpy_r_r11 = CPyStatic_abi___globals;
     cpy_r_r12 = CPyImport_ImportFromMany(cpy_r_r10, cpy_r_r9, cpy_r_r9, cpy_r_r11);
@@ -3859,7 +3859,7 @@ CPyL3: ;
     CPyModule_faster_eth_abi___codec = cpy_r_r12;
     CPy_INCREF(CPyModule_faster_eth_abi___codec);
     CPy_DECREF(cpy_r_r12);
-    cpy_r_r13 = CPyStatics[246]; /* ('registry',) */
+    cpy_r_r13 = CPyStatics[245]; /* ('registry',) */
     cpy_r_r14 = CPyStatics[70]; /* 'faster_eth_abi.registry' */
     cpy_r_r15 = CPyStatic_abi___globals;
     cpy_r_r16 = CPyImport_ImportFromMany(cpy_r_r14, cpy_r_r13, cpy_r_r13, cpy_r_r15);
@@ -4111,7 +4111,7 @@ char CPyDef_constants_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[244]; /* ('Final',) */
+    cpy_r_r5 = CPyStatics[243]; /* ('Final',) */
     cpy_r_r6 = CPyStatics[16]; /* 'typing' */
     cpy_r_r7 = CPyStatic_constants___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
@@ -4122,7 +4122,7 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r8;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r8);
-    cpy_r_r9 = (CPyTagged)CPyStatics[226] | 1; /* 115792089237316195423570985008687907853269984665640564039457584007913129639936 */
+    cpy_r_r9 = (CPyTagged)CPyStatics[225] | 1; /* 115792089237316195423570985008687907853269984665640564039457584007913129639936 */
     cpy_r_r10 = CPyStatic_constants___globals;
     cpy_r_r11 = CPyStatics[76]; /* 'TT256' */
     CPyTagged_INCREF(cpy_r_r9);
@@ -4134,7 +4134,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_abi/constants.py", "<module>", 5, CPyStatic_constants___globals);
         goto CPyL8;
     }
-    cpy_r_r15 = (CPyTagged)CPyStatics[227] | 1; /* 115792089237316195423570985008687907853269984665640564039457584007913129639935 */
+    cpy_r_r15 = (CPyTagged)CPyStatics[226] | 1; /* 115792089237316195423570985008687907853269984665640564039457584007913129639935 */
     cpy_r_r16 = CPyStatic_constants___globals;
     cpy_r_r17 = CPyStatics[77]; /* 'TT256M1' */
     CPyTagged_INCREF(cpy_r_r15);
@@ -4146,7 +4146,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_abi/constants.py", "<module>", 6, CPyStatic_constants___globals);
         goto CPyL8;
     }
-    cpy_r_r21 = (CPyTagged)CPyStatics[228] | 1; /* 57896044618658097711785492504343953926634992332820282019728792003956564819968 */
+    cpy_r_r21 = (CPyTagged)CPyStatics[227] | 1; /* 57896044618658097711785492504343953926634992332820282019728792003956564819968 */
     cpy_r_r22 = CPyStatic_constants___globals;
     cpy_r_r23 = CPyStatics[78]; /* 'TT255' */
     CPyTagged_INCREF(cpy_r_r21);
@@ -6785,13 +6785,13 @@ CPyL3: ;
     cpy_r_r7 = (void *)&cpy_r_r6;
     int64_t cpy_r_r8[1] = {1};
     cpy_r_r9 = (void *)&cpy_r_r8;
-    cpy_r_r10 = CPyStatics[248]; /* (('functools', 'functools', 'functools'),) */
+    cpy_r_r10 = CPyStatics[247]; /* (('functools', 'functools', 'functools'),) */
     cpy_r_r11 = CPyStatic_from_type_str___globals;
     cpy_r_r12 = CPyStatics[102]; /* 'faster_eth_abi/from_type_str.py' */
     cpy_r_r13 = CPyStatics[103]; /* '<module>' */
     cpy_r_r14 = CPyImport_ImportMany(cpy_r_r10, cpy_r_r7, cpy_r_r11, cpy_r_r12, cpy_r_r13, cpy_r_r9);
     if (!cpy_r_r14) goto CPyL30;
-    cpy_r_r15 = CPyStatics[249]; /* ('TYPE_CHECKING', 'Any', 'Callable', 'Optional', 'Type',
+    cpy_r_r15 = CPyStatics[248]; /* ('TYPE_CHECKING', 'Any', 'Callable', 'Optional', 'Type',
                                     'TypeVar') */
     cpy_r_r16 = CPyStatics[16]; /* 'typing' */
     cpy_r_r17 = CPyStatic_from_type_str___globals;
@@ -6803,7 +6803,7 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r18;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r18);
-    cpy_r_r19 = CPyStatics[250]; /* ('TypeStr',) */
+    cpy_r_r19 = CPyStatics[249]; /* ('TypeStr',) */
     cpy_r_r20 = CPyStatics[19]; /* 'eth_typing' */
     cpy_r_r21 = CPyStatic_from_type_str___globals;
     cpy_r_r22 = CPyImport_ImportFromMany(cpy_r_r20, cpy_r_r19, cpy_r_r19, cpy_r_r21);
@@ -6814,7 +6814,7 @@ CPyL3: ;
     CPyModule_eth_typing = cpy_r_r22;
     CPy_INCREF(CPyModule_eth_typing);
     CPy_DECREF(cpy_r_r22);
-    cpy_r_r23 = CPyStatics[251]; /* ('ABIType', 'BasicType', 'TupleType', 'normalize',
+    cpy_r_r23 = CPyStatics[250]; /* ('ABIType', 'BasicType', 'TupleType', 'normalize',
                                     'parse') */
     cpy_r_r24 = CPyStatics[106]; /* 'faster_eth_abi.grammar' */
     cpy_r_r25 = CPyStatic_from_type_str___globals;
@@ -6850,7 +6850,7 @@ CPyL3: ;
     }
     PyObject *cpy_r_r36[2] = {cpy_r_r27, cpy_r_r32};
     cpy_r_r37 = (PyObject **)&cpy_r_r36;
-    cpy_r_r38 = CPyStatics[252]; /* ('bound',) */
+    cpy_r_r38 = CPyStatics[251]; /* ('bound',) */
     cpy_r_r39 = PyObject_Vectorcall(cpy_r_r35, cpy_r_r37, 1, cpy_r_r38);
     CPy_DECREF(cpy_r_r35);
     if (unlikely(cpy_r_r39 == NULL)) {
@@ -7171,7 +7171,7 @@ char CPyDef_packed_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[244]; /* ('Final',) */
+    cpy_r_r5 = CPyStatics[243]; /* ('Final',) */
     cpy_r_r6 = CPyStatics[16]; /* 'typing' */
     cpy_r_r7 = CPyStatic_packed___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
@@ -7182,7 +7182,7 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r8;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r8);
-    cpy_r_r9 = CPyStatics[253]; /* ('ABIEncoder',) */
+    cpy_r_r9 = CPyStatics[252]; /* ('ABIEncoder',) */
     cpy_r_r10 = CPyStatics[68]; /* 'faster_eth_abi.codec' */
     cpy_r_r11 = CPyStatic_packed___globals;
     cpy_r_r12 = CPyImport_ImportFromMany(cpy_r_r10, cpy_r_r9, cpy_r_r9, cpy_r_r11);
@@ -7193,7 +7193,7 @@ CPyL3: ;
     CPyModule_faster_eth_abi___codec = cpy_r_r12;
     CPy_INCREF(CPyModule_faster_eth_abi___codec);
     CPy_DECREF(cpy_r_r12);
-    cpy_r_r13 = CPyStatics[254]; /* ('registry_packed',) */
+    cpy_r_r13 = CPyStatics[253]; /* ('registry_packed',) */
     cpy_r_r14 = CPyStatics[70]; /* 'faster_eth_abi.registry' */
     cpy_r_r15 = CPyStatic_packed___globals;
     cpy_r_r16 = CPyImport_ImportFromMany(cpy_r_r14, cpy_r_r13, cpy_r_r13, cpy_r_r15);
@@ -7373,7 +7373,7 @@ char CPyDef_tools_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[255]; /* ('get_abi_strategy',) */
+    cpy_r_r5 = CPyStatics[254]; /* ('get_abi_strategy',) */
     cpy_r_r6 = CPyStatics[118]; /* 'faster_eth_abi.tools._strategies' */
     cpy_r_r7 = CPyStatic_tools___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
@@ -7712,7 +7712,7 @@ CPyL3: ;
         cpy_r_label
     };
     cpy_r_r4 = (PyObject **)&cpy_r_r3;
-    cpy_r_r5 = CPyStatics[256]; /* ('label',) */
+    cpy_r_r5 = CPyStatics[255]; /* ('label',) */
     cpy_r_r6 = PyObject_VectorcallMethod(cpy_r_r2, cpy_r_r4, 9223372036854775812ULL, cpy_r_r5);
     if (unlikely(cpy_r_r6 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "register_strategy", 51, CPyStatic__strategies___globals);
@@ -8069,14 +8069,14 @@ PyObject *CPyDef__strategies___get_uint_strategy(PyObject *cpy_r_abi_type, PyObj
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_uint_strategy", 86, CPyStatic__strategies___globals);
         goto CPyL7;
     }
-    cpy_r_r5 = CPyStatics[229]; /* 2 */
+    cpy_r_r5 = CPyStatics[228]; /* 2 */
     cpy_r_r6 = CPyNumber_Power(cpy_r_r5, cpy_r_r1);
     CPy_DECREF(cpy_r_r1);
     if (unlikely(cpy_r_r6 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_uint_strategy", 88, CPyStatic__strategies___globals);
         goto CPyL8;
     }
-    cpy_r_r7 = CPyStatics[230]; /* 1 */
+    cpy_r_r7 = CPyStatics[229]; /* 1 */
     cpy_r_r8 = PyNumber_Subtract(cpy_r_r6, cpy_r_r7);
     CPy_DECREF(cpy_r_r6);
     if (unlikely(cpy_r_r8 == NULL)) {
@@ -8084,10 +8084,10 @@ PyObject *CPyDef__strategies___get_uint_strategy(PyObject *cpy_r_abi_type, PyObj
         goto CPyL8;
     }
     cpy_r_r9 = CPyStatics[128]; /* 'integers' */
-    cpy_r_r10 = CPyStatics[225]; /* 0 */
+    cpy_r_r10 = CPyStatics[224]; /* 0 */
     PyObject *cpy_r_r11[3] = {cpy_r_r4, cpy_r_r10, cpy_r_r8};
     cpy_r_r12 = (PyObject **)&cpy_r_r11;
-    cpy_r_r13 = CPyStatics[257]; /* ('min_value', 'max_value') */
+    cpy_r_r13 = CPyStatics[256]; /* ('min_value', 'max_value') */
     cpy_r_r14 = PyObject_VectorcallMethod(cpy_r_r9, cpy_r_r12, 9223372036854775809ULL, cpy_r_r13);
     if (unlikely(cpy_r_r14 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_uint_strategy", 86, CPyStatic__strategies___globals);
@@ -8169,13 +8169,13 @@ PyObject *CPyDef__strategies___get_int_strategy(PyObject *cpy_r_abi_type, PyObje
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_int_strategy", 97, CPyStatic__strategies___globals);
         goto CPyL11;
     }
-    cpy_r_r5 = CPyStatics[230]; /* 1 */
+    cpy_r_r5 = CPyStatics[229]; /* 1 */
     cpy_r_r6 = PyNumber_Subtract(cpy_r_r1, cpy_r_r5);
     if (unlikely(cpy_r_r6 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_int_strategy", 98, CPyStatic__strategies___globals);
         goto CPyL12;
     }
-    cpy_r_r7 = CPyStatics[229]; /* 2 */
+    cpy_r_r7 = CPyStatics[228]; /* 2 */
     cpy_r_r8 = CPyNumber_Power(cpy_r_r7, cpy_r_r6);
     CPy_DECREF(cpy_r_r6);
     if (unlikely(cpy_r_r8 == NULL)) {
@@ -8188,21 +8188,21 @@ PyObject *CPyDef__strategies___get_int_strategy(PyObject *cpy_r_abi_type, PyObje
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_int_strategy", 98, CPyStatic__strategies___globals);
         goto CPyL12;
     }
-    cpy_r_r10 = CPyStatics[230]; /* 1 */
+    cpy_r_r10 = CPyStatics[229]; /* 1 */
     cpy_r_r11 = PyNumber_Subtract(cpy_r_r1, cpy_r_r10);
     CPy_DECREF(cpy_r_r1);
     if (unlikely(cpy_r_r11 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_int_strategy", 99, CPyStatic__strategies___globals);
         goto CPyL13;
     }
-    cpy_r_r12 = CPyStatics[229]; /* 2 */
+    cpy_r_r12 = CPyStatics[228]; /* 2 */
     cpy_r_r13 = CPyNumber_Power(cpy_r_r12, cpy_r_r11);
     CPy_DECREF(cpy_r_r11);
     if (unlikely(cpy_r_r13 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_int_strategy", 99, CPyStatic__strategies___globals);
         goto CPyL13;
     }
-    cpy_r_r14 = CPyStatics[230]; /* 1 */
+    cpy_r_r14 = CPyStatics[229]; /* 1 */
     cpy_r_r15 = PyNumber_Subtract(cpy_r_r13, cpy_r_r14);
     CPy_DECREF(cpy_r_r13);
     if (unlikely(cpy_r_r15 == NULL)) {
@@ -8212,7 +8212,7 @@ PyObject *CPyDef__strategies___get_int_strategy(PyObject *cpy_r_abi_type, PyObje
     cpy_r_r16 = CPyStatics[128]; /* 'integers' */
     PyObject *cpy_r_r17[3] = {cpy_r_r4, cpy_r_r9, cpy_r_r15};
     cpy_r_r18 = (PyObject **)&cpy_r_r17;
-    cpy_r_r19 = CPyStatics[257]; /* ('min_value', 'max_value') */
+    cpy_r_r19 = CPyStatics[256]; /* ('min_value', 'max_value') */
     cpy_r_r20 = PyObject_VectorcallMethod(cpy_r_r16, cpy_r_r18, 9223372036854775809ULL, cpy_r_r19);
     if (unlikely(cpy_r_r20 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_int_strategy", 97, CPyStatic__strategies___globals);
@@ -8357,14 +8357,14 @@ CPyL11: ;
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_ufixed_strategy", 112, CPyStatic__strategies___globals);
         goto CPyL23;
     }
-    cpy_r_r12 = CPyStatics[229]; /* 2 */
+    cpy_r_r12 = CPyStatics[228]; /* 2 */
     cpy_r_r13 = CPyNumber_Power(cpy_r_r12, cpy_r_r3);
     CPy_DECREF(cpy_r_r3);
     if (unlikely(cpy_r_r13 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_ufixed_strategy", 114, CPyStatic__strategies___globals);
         goto CPyL24;
     }
-    cpy_r_r14 = CPyStatics[230]; /* 1 */
+    cpy_r_r14 = CPyStatics[229]; /* 1 */
     cpy_r_r15 = PyNumber_Subtract(cpy_r_r13, cpy_r_r14);
     CPy_DECREF(cpy_r_r13);
     if (unlikely(cpy_r_r15 == NULL)) {
@@ -8372,11 +8372,11 @@ CPyL11: ;
         goto CPyL24;
     }
     cpy_r_r16 = CPyStatics[131]; /* 'decimals' */
-    cpy_r_r17 = CPyStatics[225]; /* 0 */
-    cpy_r_r18 = CPyStatics[225]; /* 0 */
+    cpy_r_r17 = CPyStatics[224]; /* 0 */
+    cpy_r_r18 = CPyStatics[224]; /* 0 */
     PyObject *cpy_r_r19[4] = {cpy_r_r11, cpy_r_r17, cpy_r_r15, cpy_r_r18};
     cpy_r_r20 = (PyObject **)&cpy_r_r19;
-    cpy_r_r21 = CPyStatics[258]; /* ('min_value', 'max_value', 'places') */
+    cpy_r_r21 = CPyStatics[257]; /* ('min_value', 'max_value', 'places') */
     cpy_r_r22 = PyObject_VectorcallMethod(cpy_r_r16, cpy_r_r20, 9223372036854775809ULL, cpy_r_r21);
     if (unlikely(cpy_r_r22 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_ufixed_strategy", 112, CPyStatic__strategies___globals);
@@ -8568,13 +8568,13 @@ CPyL11: ;
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_fixed_strategy", 124, CPyStatic__strategies___globals);
         goto CPyL27;
     }
-    cpy_r_r12 = CPyStatics[230]; /* 1 */
+    cpy_r_r12 = CPyStatics[229]; /* 1 */
     cpy_r_r13 = PyNumber_Subtract(cpy_r_r3, cpy_r_r12);
     if (unlikely(cpy_r_r13 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_fixed_strategy", 125, CPyStatic__strategies___globals);
         goto CPyL28;
     }
-    cpy_r_r14 = CPyStatics[229]; /* 2 */
+    cpy_r_r14 = CPyStatics[228]; /* 2 */
     cpy_r_r15 = CPyNumber_Power(cpy_r_r14, cpy_r_r13);
     CPy_DECREF(cpy_r_r13);
     if (unlikely(cpy_r_r15 == NULL)) {
@@ -8587,21 +8587,21 @@ CPyL11: ;
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_fixed_strategy", 125, CPyStatic__strategies___globals);
         goto CPyL28;
     }
-    cpy_r_r17 = CPyStatics[230]; /* 1 */
+    cpy_r_r17 = CPyStatics[229]; /* 1 */
     cpy_r_r18 = PyNumber_Subtract(cpy_r_r3, cpy_r_r17);
     CPy_DECREF(cpy_r_r3);
     if (unlikely(cpy_r_r18 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_fixed_strategy", 126, CPyStatic__strategies___globals);
         goto CPyL29;
     }
-    cpy_r_r19 = CPyStatics[229]; /* 2 */
+    cpy_r_r19 = CPyStatics[228]; /* 2 */
     cpy_r_r20 = CPyNumber_Power(cpy_r_r19, cpy_r_r18);
     CPy_DECREF(cpy_r_r18);
     if (unlikely(cpy_r_r20 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_fixed_strategy", 126, CPyStatic__strategies___globals);
         goto CPyL29;
     }
-    cpy_r_r21 = CPyStatics[230]; /* 1 */
+    cpy_r_r21 = CPyStatics[229]; /* 1 */
     cpy_r_r22 = PyNumber_Subtract(cpy_r_r20, cpy_r_r21);
     CPy_DECREF(cpy_r_r20);
     if (unlikely(cpy_r_r22 == NULL)) {
@@ -8609,10 +8609,10 @@ CPyL11: ;
         goto CPyL29;
     }
     cpy_r_r23 = CPyStatics[131]; /* 'decimals' */
-    cpy_r_r24 = CPyStatics[225]; /* 0 */
+    cpy_r_r24 = CPyStatics[224]; /* 0 */
     PyObject *cpy_r_r25[4] = {cpy_r_r11, cpy_r_r16, cpy_r_r22, cpy_r_r24};
     cpy_r_r26 = (PyObject **)&cpy_r_r25;
-    cpy_r_r27 = CPyStatics[258]; /* ('min_value', 'max_value', 'places') */
+    cpy_r_r27 = CPyStatics[257]; /* ('min_value', 'max_value', 'places') */
     cpy_r_r28 = PyObject_VectorcallMethod(cpy_r_r23, cpy_r_r26, 9223372036854775809ULL, cpy_r_r27);
     if (unlikely(cpy_r_r28 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_fixed_strategy", 124, CPyStatic__strategies___globals);
@@ -8742,7 +8742,7 @@ PyObject *CPyDef__strategies___get_bytes_strategy(PyObject *cpy_r_abi_type, PyOb
     cpy_r_r5 = CPyStatics[134]; /* 'binary' */
     PyObject *cpy_r_r6[3] = {cpy_r_r4, cpy_r_r1, cpy_r_r1};
     cpy_r_r7 = (PyObject **)&cpy_r_r6;
-    cpy_r_r8 = CPyStatics[259]; /* ('min_size', 'max_size') */
+    cpy_r_r8 = CPyStatics[258]; /* ('min_size', 'max_size') */
     cpy_r_r9 = PyObject_VectorcallMethod(cpy_r_r5, cpy_r_r7, 9223372036854775809ULL, cpy_r_r8);
     if (unlikely(cpy_r_r9 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_bytes_strategy", 136, CPyStatic__strategies___globals);
@@ -8849,7 +8849,7 @@ PyObject *CPyDef__strategies___get_array_strategy(PyObject *cpy_r_abi_type, PyOb
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_array_strategy", 153, CPyStatic__strategies___globals);
         goto CPyL17;
     }
-    cpy_r_r10 = CPyStatics[231]; /* -1 */
+    cpy_r_r10 = CPyStatics[230]; /* -1 */
     cpy_r_r11 = PyObject_GetItem(cpy_r_r9, cpy_r_r10);
     CPy_DECREF(cpy_r_r9);
     if (unlikely(cpy_r_r11 == NULL)) {
@@ -8887,7 +8887,7 @@ CPyL8: ;
     CPy_DECREF(cpy_r_r7);
     return cpy_r_r20;
 CPyL11: ;
-    cpy_r_r21 = CPyStatics[225]; /* 0 */
+    cpy_r_r21 = CPyStatics[224]; /* 0 */
     cpy_r_r22 = PyObject_GetItem(cpy_r_r11, cpy_r_r21);
     CPy_DECREF(cpy_r_r11);
     if (unlikely(cpy_r_r22 == NULL)) {
@@ -8904,7 +8904,7 @@ CPyL11: ;
     cpy_r_r26 = CPyStatics[139]; /* 'lists' */
     PyObject *cpy_r_r27[4] = {cpy_r_r25, cpy_r_r7, cpy_r_r22, cpy_r_r22};
     cpy_r_r28 = (PyObject **)&cpy_r_r27;
-    cpy_r_r29 = CPyStatics[259]; /* ('min_size', 'max_size') */
+    cpy_r_r29 = CPyStatics[258]; /* ('min_size', 'max_size') */
     cpy_r_r30 = PyObject_VectorcallMethod(cpy_r_r26, cpy_r_r28, 9223372036854775810ULL, cpy_r_r29);
     if (unlikely(cpy_r_r30 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "get_array_strategy", 160, CPyStatic__strategies___globals);
@@ -9455,7 +9455,7 @@ char CPyDef__strategies_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[260]; /* ('Callable', 'Final', 'Optional', 'Union') */
+    cpy_r_r5 = CPyStatics[259]; /* ('Callable', 'Final', 'Optional', 'Union') */
     cpy_r_r6 = CPyStatics[16]; /* 'typing' */
     cpy_r_r7 = CPyStatic__strategies___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
@@ -9466,7 +9466,7 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r8;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r8);
-    cpy_r_r9 = CPyStatics[261]; /* ('to_checksum_address',) */
+    cpy_r_r9 = CPyStatics[260]; /* ('to_checksum_address',) */
     cpy_r_r10 = CPyStatics[144]; /* 'cchecksum' */
     cpy_r_r11 = CPyStatic__strategies___globals;
     cpy_r_r12 = CPyImport_ImportFromMany(cpy_r_r10, cpy_r_r9, cpy_r_r9, cpy_r_r11);
@@ -9477,7 +9477,7 @@ CPyL3: ;
     CPyModule_cchecksum = cpy_r_r12;
     CPy_INCREF(CPyModule_cchecksum);
     CPy_DECREF(cpy_r_r12);
-    cpy_r_r13 = CPyStatics[250]; /* ('TypeStr',) */
+    cpy_r_r13 = CPyStatics[249]; /* ('TypeStr',) */
     cpy_r_r14 = CPyStatics[145]; /* 'eth_typing.abi' */
     cpy_r_r15 = CPyStatic__strategies___globals;
     cpy_r_r16 = CPyImport_ImportFromMany(cpy_r_r14, cpy_r_r13, cpy_r_r13, cpy_r_r15);
@@ -9488,8 +9488,8 @@ CPyL3: ;
     CPyModule_eth_typing___abi = cpy_r_r16;
     CPy_INCREF(CPyModule_eth_typing___abi);
     CPy_DECREF(cpy_r_r16);
-    cpy_r_r17 = CPyStatics[262]; /* ('strategies',) */
-    cpy_r_r18 = CPyStatics[263]; /* ('st',) */
+    cpy_r_r17 = CPyStatics[261]; /* ('strategies',) */
+    cpy_r_r18 = CPyStatics[262]; /* ('st',) */
     cpy_r_r19 = CPyStatics[147]; /* 'hypothesis' */
     cpy_r_r20 = CPyStatic__strategies___globals;
     cpy_r_r21 = CPyImport_ImportFromMany(cpy_r_r19, cpy_r_r17, cpy_r_r18, cpy_r_r20);
@@ -9500,7 +9500,7 @@ CPyL3: ;
     CPyModule_hypothesis = cpy_r_r21;
     CPy_INCREF(CPyModule_hypothesis);
     CPy_DECREF(cpy_r_r21);
-    cpy_r_r22 = CPyStatics[251]; /* ('ABIType', 'BasicType', 'TupleType', 'normalize',
+    cpy_r_r22 = CPyStatics[250]; /* ('ABIType', 'BasicType', 'TupleType', 'normalize',
                                     'parse') */
     cpy_r_r23 = CPyStatics[106]; /* 'faster_eth_abi.grammar' */
     cpy_r_r24 = CPyStatic__strategies___globals;
@@ -9512,7 +9512,7 @@ CPyL3: ;
     CPyModule_faster_eth_abi___grammar = cpy_r_r25;
     CPy_INCREF(CPyModule_faster_eth_abi___grammar);
     CPy_DECREF(cpy_r_r25);
-    cpy_r_r26 = CPyStatics[264]; /* ('BaseEquals', 'BaseRegistry', 'Lookup',
+    cpy_r_r26 = CPyStatics[263]; /* ('BaseEquals', 'BaseRegistry', 'Lookup',
                                     'PredicateMapping', 'has_arrlist', 'is_base_tuple') */
     cpy_r_r27 = CPyStatics[70]; /* 'faster_eth_abi.registry' */
     cpy_r_r28 = CPyStatic__strategies___globals;
@@ -9524,7 +9524,7 @@ CPyL3: ;
     CPyModule_faster_eth_abi___registry = cpy_r_r29;
     CPy_INCREF(CPyModule_faster_eth_abi___registry);
     CPy_DECREF(cpy_r_r29);
-    cpy_r_r30 = CPyStatics[265]; /* ('scale_places',) */
+    cpy_r_r30 = CPyStatics[264]; /* ('scale_places',) */
     cpy_r_r31 = CPyStatics[154]; /* 'faster_eth_abi.utils.numeric' */
     cpy_r_r32 = CPyStatic__strategies___globals;
     cpy_r_r33 = CPyImport_ImportFromMany(cpy_r_r31, cpy_r_r30, cpy_r_r30, cpy_r_r32);
@@ -9713,11 +9713,11 @@ CPyL3: ;
         goto CPyL142;
     }
     cpy_r_r96 = CPyStatics[134]; /* 'binary' */
-    cpy_r_r97 = CPyStatics[232]; /* 20 */
-    cpy_r_r98 = CPyStatics[232]; /* 20 */
+    cpy_r_r97 = CPyStatics[231]; /* 20 */
+    cpy_r_r98 = CPyStatics[231]; /* 20 */
     PyObject *cpy_r_r99[3] = {cpy_r_r95, cpy_r_r97, cpy_r_r98};
     cpy_r_r100 = (PyObject **)&cpy_r_r99;
-    cpy_r_r101 = CPyStatics[259]; /* ('min_size', 'max_size') */
+    cpy_r_r101 = CPyStatics[258]; /* ('min_size', 'max_size') */
     cpy_r_r102 = PyObject_VectorcallMethod(cpy_r_r96, cpy_r_r100, 9223372036854775809ULL, cpy_r_r101);
     if (unlikely(cpy_r_r102 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "<module>", 103, CPyStatic__strategies___globals);
@@ -9787,11 +9787,11 @@ CPyL3: ;
         goto CPyL142;
     }
     cpy_r_r128 = CPyStatics[134]; /* 'binary' */
-    cpy_r_r129 = CPyStatics[225]; /* 0 */
-    cpy_r_r130 = CPyStatics[233]; /* 4096 */
+    cpy_r_r129 = CPyStatics[224]; /* 0 */
+    cpy_r_r130 = CPyStatics[232]; /* 4096 */
     PyObject *cpy_r_r131[3] = {cpy_r_r127, cpy_r_r129, cpy_r_r130};
     cpy_r_r132 = (PyObject **)&cpy_r_r131;
-    cpy_r_r133 = CPyStatics[259]; /* ('min_size', 'max_size') */
+    cpy_r_r133 = CPyStatics[258]; /* ('min_size', 'max_size') */
     cpy_r_r134 = PyObject_VectorcallMethod(cpy_r_r128, cpy_r_r132, 9223372036854775809ULL, cpy_r_r133);
     if (unlikely(cpy_r_r134 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/tools/_strategies.py", "<module>", 142, CPyStatic__strategies___globals);
@@ -9955,7 +9955,7 @@ CPyL63: ;
     cpy_r_r189 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r190[2] = {cpy_r_r185, cpy_r_r189};
     cpy_r_r191 = (PyObject **)&cpy_r_r190;
-    cpy_r_r192 = CPyStatics[266]; /* ('with_sub',) */
+    cpy_r_r192 = CPyStatics[265]; /* ('with_sub',) */
     cpy_r_r193 = PyObject_Vectorcall(cpy_r_r188, cpy_r_r191, 1, cpy_r_r192);
     CPy_DECREF(cpy_r_r188);
     if (unlikely(cpy_r_r193 == NULL)) {
@@ -10004,7 +10004,7 @@ CPyL72: ;
     cpy_r_r204 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r205[2] = {cpy_r_r200, cpy_r_r204};
     cpy_r_r206 = (PyObject **)&cpy_r_r205;
-    cpy_r_r207 = CPyStatics[266]; /* ('with_sub',) */
+    cpy_r_r207 = CPyStatics[265]; /* ('with_sub',) */
     cpy_r_r208 = PyObject_Vectorcall(cpy_r_r203, cpy_r_r206, 1, cpy_r_r207);
     CPy_DECREF(cpy_r_r203);
     if (unlikely(cpy_r_r208 == NULL)) {
@@ -10135,7 +10135,7 @@ CPyL95: ;
     cpy_r_r247 = 1 ? Py_True : Py_False;
     PyObject *cpy_r_r248[2] = {cpy_r_r243, cpy_r_r247};
     cpy_r_r249 = (PyObject **)&cpy_r_r248;
-    cpy_r_r250 = CPyStatics[266]; /* ('with_sub',) */
+    cpy_r_r250 = CPyStatics[265]; /* ('with_sub',) */
     cpy_r_r251 = PyObject_Vectorcall(cpy_r_r246, cpy_r_r249, 1, cpy_r_r250);
     CPy_DECREF(cpy_r_r246);
     if (unlikely(cpy_r_r251 == NULL)) {
@@ -10178,7 +10178,7 @@ CPyL102: ;
     cpy_r_r263 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r264[2] = {cpy_r_r259, cpy_r_r263};
     cpy_r_r265 = (PyObject **)&cpy_r_r264;
-    cpy_r_r266 = CPyStatics[266]; /* ('with_sub',) */
+    cpy_r_r266 = CPyStatics[265]; /* ('with_sub',) */
     cpy_r_r267 = PyObject_Vectorcall(cpy_r_r262, cpy_r_r265, 1, cpy_r_r266);
     CPy_DECREF(cpy_r_r262);
     if (unlikely(cpy_r_r267 == NULL)) {
@@ -10227,7 +10227,7 @@ CPyL111: ;
     cpy_r_r278 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r279[2] = {cpy_r_r274, cpy_r_r278};
     cpy_r_r280 = (PyObject **)&cpy_r_r279;
-    cpy_r_r281 = CPyStatics[266]; /* ('with_sub',) */
+    cpy_r_r281 = CPyStatics[265]; /* ('with_sub',) */
     cpy_r_r282 = PyObject_Vectorcall(cpy_r_r277, cpy_r_r280, 1, cpy_r_r281);
     CPy_DECREF(cpy_r_r277);
     if (unlikely(cpy_r_r282 == NULL)) {
@@ -10270,7 +10270,7 @@ CPyL118: ;
     cpy_r_r294 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r295[2] = {cpy_r_r290, cpy_r_r294};
     cpy_r_r296 = (PyObject **)&cpy_r_r295;
-    cpy_r_r297 = CPyStatics[266]; /* ('with_sub',) */
+    cpy_r_r297 = CPyStatics[265]; /* ('with_sub',) */
     cpy_r_r298 = PyObject_Vectorcall(cpy_r_r293, cpy_r_r296, 1, cpy_r_r297);
     CPy_DECREF(cpy_r_r293);
     if (unlikely(cpy_r_r298 == NULL)) {
@@ -10875,8 +10875,6 @@ int CPyExec_faster_eth_abi___utils___numeric(PyObject *module)
     Py_CLEAR(modname);
     CPy_XDECREF(CPyStatic_numeric___abi_decimal_context);
     CPyStatic_numeric___abi_decimal_context = NULL;
-    CPy_XDECREF(CPyStatic_numeric___decimal_localcontext);
-    CPyStatic_numeric___decimal_localcontext = NULL;
     CPy_XDECREF(CPyStatic_numeric___ZERO);
     CPyStatic_numeric___ZERO = NULL;
     CPy_XDECREF(CPyStatic_numeric___TEN);
@@ -10930,7 +10928,7 @@ CPyTagged CPyDef_numeric___ceil32(CPyTagged cpy_r_x) {
     CPyTagged cpy_r_r6;
     cpy_r_r0 = CPyTagged_Remainder(cpy_r_x, 64);
     if (unlikely(cpy_r_r0 == CPY_INT_TAG)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "ceil32", 21, CPyStatic_numeric___globals);
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "ceil32", 20, CPyStatic_numeric___globals);
         goto CPyL6;
     }
     cpy_r_r1 = cpy_r_r0 == 0;
@@ -10943,7 +10941,7 @@ CPyL3: ;
     cpy_r_r3 = CPyTagged_Add(cpy_r_x, 64);
     cpy_r_r4 = CPyTagged_Remainder(cpy_r_x, 64);
     if (unlikely(cpy_r_r4 == CPY_INT_TAG)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "ceil32", 22, CPyStatic_numeric___globals);
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "ceil32", 21, CPyStatic_numeric___globals);
         goto CPyL7;
     }
     cpy_r_r5 = CPyTagged_Subtract(cpy_r_r3, cpy_r_r4);
@@ -10980,7 +10978,7 @@ PyObject *CPyPy_numeric___ceil32(PyObject *self, PyObject *const *args, size_t n
     PyObject *retbox = CPyTagged_StealAsObject(retval);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "ceil32", 20, CPyStatic_numeric___globals);
+    CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "ceil32", 19, CPyStatic_numeric___globals);
     return NULL;
 }
 
@@ -11014,7 +11012,7 @@ tuple_T2II CPyDef_numeric___compute_unsigned_integer_bounds(CPyTagged cpy_r_num_
     PyErr_SetString(PyExc_NameError, "value for final name \"_unsigned_integer_bounds_cache\" was not set");
     cpy_r_r1 = 0;
     if (unlikely(!cpy_r_r1)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 29, CPyStatic_numeric___globals);
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 28, CPyStatic_numeric___globals);
         goto CPyL15;
     }
     CPy_Unreachable();
@@ -11024,7 +11022,7 @@ CPyL3: ;
     cpy_r_r3 = CPyDict_GetWithNone(cpy_r_r0, cpy_r_r2);
     CPy_DECREF(cpy_r_r2);
     if (unlikely(cpy_r_r3 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 29, CPyStatic_numeric___globals);
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 28, CPyStatic_numeric___globals);
         goto CPyL15;
     }
     if (unlikely(!(PyTuple_Check(cpy_r_r3) && PyTuple_GET_SIZE(cpy_r_r3) == 2))) {
@@ -11052,7 +11050,7 @@ __LL22: ;
         cpy_r_r4 = NULL;
     }
     if (cpy_r_r4 != NULL) goto __LL21;
-    CPy_TypeErrorTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 29, CPyStatic_numeric___globals, "tuple[int, int] or None", cpy_r_r3);
+    CPy_TypeErrorTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 28, CPyStatic_numeric___globals, "tuple[int, int] or None", cpy_r_r3);
     goto CPyL15;
 __LL21: ;
     cpy_r_bounds = cpy_r_r4;
@@ -11063,20 +11061,20 @@ __LL21: ;
     } else
         goto CPyL13;
 CPyL6: ;
-    cpy_r_r7 = CPyStatics[229]; /* 2 */
+    cpy_r_r7 = CPyStatics[228]; /* 2 */
     CPyTagged_INCREF(cpy_r_num_bits);
     cpy_r_r8 = CPyTagged_StealAsObject(cpy_r_num_bits);
     cpy_r_r9 = CPyNumber_Power(cpy_r_r7, cpy_r_r8);
     CPy_DECREF(cpy_r_r8);
     if (unlikely(cpy_r_r9 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 31, CPyStatic_numeric___globals);
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 30, CPyStatic_numeric___globals);
         goto CPyL15;
     }
-    cpy_r_r10 = CPyStatics[230]; /* 1 */
+    cpy_r_r10 = CPyStatics[229]; /* 1 */
     cpy_r_r11 = PyNumber_Subtract(cpy_r_r9, cpy_r_r10);
     CPy_DECREF(cpy_r_r9);
     if (unlikely(cpy_r_r11 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 31, CPyStatic_numeric___globals);
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 30, CPyStatic_numeric___globals);
         goto CPyL15;
     }
     cpy_r_r12.f0 = 0;
@@ -11129,7 +11127,7 @@ __LL26: ;
         cpy_r_r14.f1 = __tmp30;
     }
     if (unlikely(cpy_r_r14.f0 == CPY_INT_TAG)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 32, CPyStatic_numeric___globals);
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 31, CPyStatic_numeric___globals);
         goto CPyL17;
     }
     cpy_r_r15 = CPyStatic_numeric____unsigned_integer_bounds_cache;
@@ -11141,7 +11139,7 @@ CPyL10: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"_unsigned_integer_bounds_cache\" was not set");
     cpy_r_r16 = 0;
     if (unlikely(!cpy_r_r16)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 32, CPyStatic_numeric___globals);
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 31, CPyStatic_numeric___globals);
         goto CPyL15;
     }
     CPy_Unreachable();
@@ -11160,7 +11158,7 @@ CPyL12: ;
     CPy_DECREF(cpy_r_r18);
     cpy_r_r20 = cpy_r_r19 >= 0;
     if (unlikely(!cpy_r_r20)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 32, CPyStatic_numeric___globals);
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 31, CPyStatic_numeric___globals);
         goto CPyL17;
     }
 CPyL13: ;
@@ -11205,7 +11203,7 @@ __LL34: ;
     }
     CPy_DECREF(cpy_r_bounds);
     if (unlikely(cpy_r_r21.f0 == CPY_INT_TAG)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 33, CPyStatic_numeric___globals);
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 32, CPyStatic_numeric___globals);
         goto CPyL15;
     }
     return cpy_r_r21;
@@ -11252,7 +11250,7 @@ PyObject *CPyPy_numeric___compute_unsigned_integer_bounds(PyObject *self, PyObje
     PyTuple_SET_ITEM(retbox, 1, __tmp41);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 28, CPyStatic_numeric___globals);
+    CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_integer_bounds", 27, CPyStatic_numeric___globals);
     return NULL;
 }
 
@@ -11271,25 +11269,30 @@ tuple_T2II CPyDef_numeric___compute_signed_integer_bounds(CPyTagged cpy_r_num_bi
     PyObject *cpy_r_r10;
     PyObject *cpy_r_r11;
     PyObject *cpy_r_r12;
-    PyObject *cpy_r_r13;
-    tuple_T2OO cpy_r_r14;
+    CPyTagged cpy_r_r13;
+    PyObject *cpy_r_r14;
     PyObject *cpy_r_r15;
-    tuple_T2II cpy_r_r16;
+    PyObject *cpy_r_r16;
     PyObject *cpy_r_r17;
-    char cpy_r_r18;
-    PyObject *cpy_r_r19;
+    PyObject *cpy_r_r18;
+    tuple_T2OO cpy_r_r19;
     PyObject *cpy_r_r20;
-    int32_t cpy_r_r21;
-    char cpy_r_r22;
-    tuple_T2II cpy_r_r23;
-    tuple_T2II cpy_r_r24;
+    tuple_T2II cpy_r_r21;
+    PyObject *cpy_r_r22;
+    char cpy_r_r23;
+    PyObject *cpy_r_r24;
+    PyObject *cpy_r_r25;
+    int32_t cpy_r_r26;
+    char cpy_r_r27;
+    tuple_T2II cpy_r_r28;
+    tuple_T2II cpy_r_r29;
     cpy_r_r0 = CPyStatic_numeric____signed_integer_bounds_cache;
     if (likely(cpy_r_r0 != NULL)) goto CPyL3;
     PyErr_SetString(PyExc_NameError, "value for final name \"_signed_integer_bounds_cache\" was not set");
     cpy_r_r1 = 0;
     if (unlikely(!cpy_r_r1)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 40, CPyStatic_numeric___globals);
-        goto CPyL16;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 39, CPyStatic_numeric___globals);
+        goto CPyL17;
     }
     CPy_Unreachable();
 CPyL3: ;
@@ -11298,8 +11301,8 @@ CPyL3: ;
     cpy_r_r3 = CPyDict_GetWithNone(cpy_r_r0, cpy_r_r2);
     CPy_DECREF(cpy_r_r2);
     if (unlikely(cpy_r_r3 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 40, CPyStatic_numeric___globals);
-        goto CPyL16;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 39, CPyStatic_numeric___globals);
+        goto CPyL17;
     }
     if (unlikely(!(PyTuple_Check(cpy_r_r3) && PyTuple_GET_SIZE(cpy_r_r3) == 2))) {
         cpy_r_r4 = NULL;
@@ -11326,48 +11329,59 @@ __LL43: ;
         cpy_r_r4 = NULL;
     }
     if (cpy_r_r4 != NULL) goto __LL42;
-    CPy_TypeErrorTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 40, CPyStatic_numeric___globals, "tuple[int, int] or None", cpy_r_r3);
-    goto CPyL16;
+    CPy_TypeErrorTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 39, CPyStatic_numeric___globals, "tuple[int, int] or None", cpy_r_r3);
+    goto CPyL17;
 __LL42: ;
     cpy_r_bounds = cpy_r_r4;
     cpy_r_r5 = (PyObject *)&_Py_NoneStruct;
     cpy_r_r6 = cpy_r_bounds == cpy_r_r5;
     if (cpy_r_r6) {
-        goto CPyL17;
+        goto CPyL18;
     } else
-        goto CPyL14;
+        goto CPyL15;
 CPyL6: ;
     cpy_r_r7 = CPyTagged_Subtract(cpy_r_num_bits, 2);
-    cpy_r_r8 = CPyStatics[229]; /* 2 */
+    cpy_r_r8 = CPyStatics[228]; /* 2 */
     cpy_r_r9 = CPyTagged_StealAsObject(cpy_r_r7);
     cpy_r_r10 = CPyNumber_Power(cpy_r_r8, cpy_r_r9);
     CPy_DECREF(cpy_r_r9);
     if (unlikely(cpy_r_r10 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 42, CPyStatic_numeric___globals);
-        goto CPyL16;
+        goto CPyL17;
     }
-    cpy_r_r11 = PyNumber_Negative(cpy_r_r10);
-    if (unlikely(cpy_r_r11 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 43, CPyStatic_numeric___globals);
-        goto CPyL18;
-    }
-    cpy_r_r12 = CPyStatics[230]; /* 1 */
-    cpy_r_r13 = PyNumber_Subtract(cpy_r_r10, cpy_r_r12);
+    cpy_r_r11 = CPyStatics[230]; /* -1 */
+    cpy_r_r12 = PyNumber_Multiply(cpy_r_r11, cpy_r_r10);
     CPy_DECREF(cpy_r_r10);
-    if (unlikely(cpy_r_r13 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 44, CPyStatic_numeric___globals);
+    if (unlikely(cpy_r_r12 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 42, CPyStatic_numeric___globals);
+        goto CPyL17;
+    }
+    cpy_r_r13 = CPyTagged_Subtract(cpy_r_num_bits, 2);
+    cpy_r_r14 = CPyStatics[228]; /* 2 */
+    cpy_r_r15 = CPyTagged_StealAsObject(cpy_r_r13);
+    cpy_r_r16 = CPyNumber_Power(cpy_r_r14, cpy_r_r15);
+    CPy_DECREF(cpy_r_r15);
+    if (unlikely(cpy_r_r16 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 43, CPyStatic_numeric___globals);
         goto CPyL19;
     }
-    cpy_r_r14.f0 = cpy_r_r11;
-    cpy_r_r14.f1 = cpy_r_r13;
-    cpy_r_r15 = PyTuple_New(2);
-    if (unlikely(cpy_r_r15 == NULL))
+    cpy_r_r17 = CPyStatics[229]; /* 1 */
+    cpy_r_r18 = PyNumber_Subtract(cpy_r_r16, cpy_r_r17);
+    CPy_DECREF(cpy_r_r16);
+    if (unlikely(cpy_r_r18 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 43, CPyStatic_numeric___globals);
+        goto CPyL19;
+    }
+    cpy_r_r19.f0 = cpy_r_r12;
+    cpy_r_r19.f1 = cpy_r_r18;
+    cpy_r_r20 = PyTuple_New(2);
+    if (unlikely(cpy_r_r20 == NULL))
         CPyError_OutOfMemory();
-    PyObject *__tmp44 = cpy_r_r14.f0;
-    PyTuple_SET_ITEM(cpy_r_r15, 0, __tmp44);
-    PyObject *__tmp45 = cpy_r_r14.f1;
-    PyTuple_SET_ITEM(cpy_r_r15, 1, __tmp45);
-    cpy_r_bounds = cpy_r_r15;
+    PyObject *__tmp44 = cpy_r_r19.f0;
+    PyTuple_SET_ITEM(cpy_r_r20, 0, __tmp44);
+    PyObject *__tmp45 = cpy_r_r19.f1;
+    PyTuple_SET_ITEM(cpy_r_r20, 1, __tmp45);
+    cpy_r_bounds = cpy_r_r20;
     PyObject *__tmp46;
     if (unlikely(!(PyTuple_Check(cpy_r_bounds) && PyTuple_GET_SIZE(cpy_r_bounds) == 2))) {
         __tmp46 = NULL;
@@ -11388,7 +11402,7 @@ CPyL6: ;
     __tmp46 = cpy_r_bounds;
 __LL47: ;
     if (unlikely(__tmp46 == NULL)) {
-        CPy_TypeError("tuple[int, int]", cpy_r_bounds); cpy_r_r16 = (tuple_T2II) { CPY_INT_TAG, CPY_INT_TAG };
+        CPy_TypeError("tuple[int, int]", cpy_r_bounds); cpy_r_r21 = (tuple_T2II) { CPY_INT_TAG, CPY_INT_TAG };
     } else {
         PyObject *__tmp48 = PyTuple_GET_ITEM(cpy_r_bounds, 0);
         CPyTagged __tmp49;
@@ -11397,7 +11411,7 @@ __LL47: ;
         else {
             CPy_TypeError("int", __tmp48); __tmp49 = CPY_INT_TAG;
         }
-        cpy_r_r16.f0 = __tmp49;
+        cpy_r_r21.f0 = __tmp49;
         PyObject *__tmp50 = PyTuple_GET_ITEM(cpy_r_bounds, 1);
         CPyTagged __tmp51;
         if (likely(PyLong_Check(__tmp50)))
@@ -11405,44 +11419,44 @@ __LL47: ;
         else {
             CPy_TypeError("int", __tmp50); __tmp51 = CPY_INT_TAG;
         }
-        cpy_r_r16.f1 = __tmp51;
+        cpy_r_r21.f1 = __tmp51;
     }
-    if (unlikely(cpy_r_r16.f0 == CPY_INT_TAG)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 46, CPyStatic_numeric___globals);
+    if (unlikely(cpy_r_r21.f0 == CPY_INT_TAG)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 45, CPyStatic_numeric___globals);
         goto CPyL20;
     }
-    cpy_r_r17 = CPyStatic_numeric____signed_integer_bounds_cache;
-    if (unlikely(cpy_r_r17 == NULL)) {
+    cpy_r_r22 = CPyStatic_numeric____signed_integer_bounds_cache;
+    if (unlikely(cpy_r_r22 == NULL)) {
         goto CPyL21;
     } else
-        goto CPyL13;
-CPyL11: ;
+        goto CPyL14;
+CPyL12: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"_signed_integer_bounds_cache\" was not set");
-    cpy_r_r18 = 0;
-    if (unlikely(!cpy_r_r18)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 46, CPyStatic_numeric___globals);
-        goto CPyL16;
+    cpy_r_r23 = 0;
+    if (unlikely(!cpy_r_r23)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 45, CPyStatic_numeric___globals);
+        goto CPyL17;
     }
     CPy_Unreachable();
-CPyL13: ;
+CPyL14: ;
     CPyTagged_INCREF(cpy_r_num_bits);
-    cpy_r_r19 = CPyTagged_StealAsObject(cpy_r_num_bits);
-    cpy_r_r20 = PyTuple_New(2);
-    if (unlikely(cpy_r_r20 == NULL))
+    cpy_r_r24 = CPyTagged_StealAsObject(cpy_r_num_bits);
+    cpy_r_r25 = PyTuple_New(2);
+    if (unlikely(cpy_r_r25 == NULL))
         CPyError_OutOfMemory();
-    PyObject *__tmp52 = CPyTagged_StealAsObject(cpy_r_r16.f0);
-    PyTuple_SET_ITEM(cpy_r_r20, 0, __tmp52);
-    PyObject *__tmp53 = CPyTagged_StealAsObject(cpy_r_r16.f1);
-    PyTuple_SET_ITEM(cpy_r_r20, 1, __tmp53);
-    cpy_r_r21 = CPyDict_SetItem(cpy_r_r17, cpy_r_r19, cpy_r_r20);
-    CPy_DECREF(cpy_r_r19);
-    CPy_DECREF(cpy_r_r20);
-    cpy_r_r22 = cpy_r_r21 >= 0;
-    if (unlikely(!cpy_r_r22)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 46, CPyStatic_numeric___globals);
+    PyObject *__tmp52 = CPyTagged_StealAsObject(cpy_r_r21.f0);
+    PyTuple_SET_ITEM(cpy_r_r25, 0, __tmp52);
+    PyObject *__tmp53 = CPyTagged_StealAsObject(cpy_r_r21.f1);
+    PyTuple_SET_ITEM(cpy_r_r25, 1, __tmp53);
+    cpy_r_r26 = CPyDict_SetItem(cpy_r_r22, cpy_r_r24, cpy_r_r25);
+    CPy_DECREF(cpy_r_r24);
+    CPy_DECREF(cpy_r_r25);
+    cpy_r_r27 = cpy_r_r26 >= 0;
+    if (unlikely(!cpy_r_r27)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 45, CPyStatic_numeric___globals);
         goto CPyL20;
     }
-CPyL14: ;
+CPyL15: ;
     PyObject *__tmp54;
     if (unlikely(!(PyTuple_Check(cpy_r_bounds) && PyTuple_GET_SIZE(cpy_r_bounds) == 2))) {
         __tmp54 = NULL;
@@ -11463,7 +11477,7 @@ CPyL14: ;
     __tmp54 = cpy_r_bounds;
 __LL55: ;
     if (unlikely(__tmp54 == NULL)) {
-        CPy_TypeError("tuple[int, int]", cpy_r_bounds); cpy_r_r23 = (tuple_T2II) { CPY_INT_TAG, CPY_INT_TAG };
+        CPy_TypeError("tuple[int, int]", cpy_r_bounds); cpy_r_r28 = (tuple_T2II) { CPY_INT_TAG, CPY_INT_TAG };
     } else {
         PyObject *__tmp56 = PyTuple_GET_ITEM(cpy_r_bounds, 0);
         CPyTagged __tmp57;
@@ -11472,7 +11486,7 @@ __LL55: ;
         else {
             CPy_TypeError("int", __tmp56); __tmp57 = CPY_INT_TAG;
         }
-        cpy_r_r23.f0 = __tmp57;
+        cpy_r_r28.f0 = __tmp57;
         PyObject *__tmp58 = PyTuple_GET_ITEM(cpy_r_bounds, 1);
         CPyTagged __tmp59;
         if (likely(PyLong_Check(__tmp58)))
@@ -11480,35 +11494,32 @@ __LL55: ;
         else {
             CPy_TypeError("int", __tmp58); __tmp59 = CPY_INT_TAG;
         }
-        cpy_r_r23.f1 = __tmp59;
+        cpy_r_r28.f1 = __tmp59;
     }
     CPy_DECREF(cpy_r_bounds);
-    if (unlikely(cpy_r_r23.f0 == CPY_INT_TAG)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 47, CPyStatic_numeric___globals);
-        goto CPyL16;
+    if (unlikely(cpy_r_r28.f0 == CPY_INT_TAG)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 46, CPyStatic_numeric___globals);
+        goto CPyL17;
     }
-    return cpy_r_r23;
-CPyL16: ;
-    tuple_T2II __tmp60 = { CPY_INT_TAG, CPY_INT_TAG };
-    cpy_r_r24 = __tmp60;
-    return cpy_r_r24;
+    return cpy_r_r28;
 CPyL17: ;
+    tuple_T2II __tmp60 = { CPY_INT_TAG, CPY_INT_TAG };
+    cpy_r_r29 = __tmp60;
+    return cpy_r_r29;
+CPyL18: ;
     CPy_DECREF(cpy_r_bounds);
     goto CPyL6;
-CPyL18: ;
-    CPy_DecRef(cpy_r_r10);
-    goto CPyL16;
 CPyL19: ;
-    CPy_DecRef(cpy_r_r11);
-    goto CPyL16;
+    CPy_DecRef(cpy_r_r12);
+    goto CPyL17;
 CPyL20: ;
     CPy_DecRef(cpy_r_bounds);
-    goto CPyL16;
+    goto CPyL17;
 CPyL21: ;
     CPy_DecRef(cpy_r_bounds);
-    CPyTagged_DecRef(cpy_r_r16.f0);
-    CPyTagged_DecRef(cpy_r_r16.f1);
-    goto CPyL11;
+    CPyTagged_DecRef(cpy_r_r21.f0);
+    CPyTagged_DecRef(cpy_r_r21.f1);
+    goto CPyL12;
 }
 
 PyObject *CPyPy_numeric___compute_signed_integer_bounds(PyObject *self, PyObject *const *args, size_t nargs, PyObject *kwnames) {
@@ -11537,7 +11548,7 @@ PyObject *CPyPy_numeric___compute_signed_integer_bounds(PyObject *self, PyObject
     PyTuple_SET_ITEM(retbox, 1, __tmp62);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 39, CPyStatic_numeric___globals);
+    CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_integer_bounds", 38, CPyStatic_numeric___globals);
     return NULL;
 }
 
@@ -11550,71 +11561,69 @@ tuple_T2OO CPyDef_numeric___compute_unsigned_fixed_bounds(CPyTagged cpy_r_num_bi
     PyObject *cpy_r_upper;
     PyObject *cpy_r_r5;
     char cpy_r_r6;
-    CPyTagged cpy_r_r7;
-    PyObject *cpy_r_r8;
+    tuple_T2II cpy_r_r7;
+    CPyTagged cpy_r_r8;
     PyObject *cpy_r_r9;
-    PyObject *cpy_r_r10;
+    char cpy_r_r10;
     PyObject *cpy_r_r11;
     PyObject *cpy_r_r12;
     PyObject *cpy_r_r13;
-    char cpy_r_r14;
-    PyObject *cpy_r_r15;
-    char cpy_r_r16;
-    PyObject **cpy_r_r18;
+    PyObject **cpy_r_r15;
+    PyObject *cpy_r_r16;
+    PyObject *cpy_r_r17;
+    PyObject *cpy_r_r18;
     PyObject *cpy_r_r19;
     PyObject *cpy_r_r20;
     PyObject *cpy_r_r21;
-    PyObject *cpy_r_r22;
-    PyObject *cpy_r_r23;
+    PyObject **cpy_r_r23;
     PyObject *cpy_r_r24;
-    PyObject **cpy_r_r26;
-    PyObject *cpy_r_r27;
-    char cpy_r_r28;
-    PyObject *cpy_r_r29;
-    char cpy_r_r30;
-    PyObject **cpy_r_r32;
-    PyObject *cpy_r_r33;
-    PyObject *cpy_r_r34;
-    char cpy_r_r35;
-    CPyTagged cpy_r_r36;
+    char cpy_r_r25;
+    PyObject *cpy_r_r26;
+    char cpy_r_r27;
+    PyObject *cpy_r_r28;
+    PyObject **cpy_r_r30;
+    PyObject *cpy_r_r31;
+    PyObject *cpy_r_r32;
+    char cpy_r_r33;
+    CPyTagged cpy_r_r34;
+    PyObject *cpy_r_r35;
+    PyObject *cpy_r_r36;
     PyObject *cpy_r_r37;
-    PyObject *cpy_r_r38;
-    PyObject *cpy_r_r39;
-    tuple_T3OOO cpy_r_r40;
-    tuple_T3OOO cpy_r_r41;
+    tuple_T3OOO cpy_r_r38;
+    tuple_T3OOO cpy_r_r39;
+    PyObject *cpy_r_r40;
+    PyObject *cpy_r_r41;
     PyObject *cpy_r_r42;
-    PyObject *cpy_r_r43;
-    PyObject *cpy_r_r44;
-    PyObject **cpy_r_r46;
-    PyObject *cpy_r_r47;
-    int32_t cpy_r_r48;
+    PyObject **cpy_r_r44;
+    PyObject *cpy_r_r45;
+    int32_t cpy_r_r46;
+    char cpy_r_r47;
+    char cpy_r_r48;
     char cpy_r_r49;
-    char cpy_r_r50;
-    char cpy_r_r51;
+    tuple_T3OOO cpy_r_r50;
+    tuple_T3OOO cpy_r_r51;
     tuple_T3OOO cpy_r_r52;
-    tuple_T3OOO cpy_r_r53;
-    tuple_T3OOO cpy_r_r54;
-    PyObject *cpy_r_r55;
-    PyObject **cpy_r_r57;
+    PyObject *cpy_r_r53;
+    PyObject **cpy_r_r55;
+    PyObject *cpy_r_r56;
+    char cpy_r_r57;
     PyObject *cpy_r_r58;
     char cpy_r_r59;
-    PyObject *cpy_r_r60;
-    char cpy_r_r61;
-    tuple_T2II cpy_r_r62;
-    PyObject *cpy_r_r63;
-    int32_t cpy_r_r64;
+    tuple_T2II cpy_r_r60;
+    PyObject *cpy_r_r61;
+    int32_t cpy_r_r62;
+    char cpy_r_r63;
+    PyObject *cpy_r_r64;
     char cpy_r_r65;
-    PyObject *cpy_r_r66;
-    char cpy_r_r67;
-    tuple_T2OO cpy_r_r68;
-    tuple_T2OO cpy_r_r69;
+    tuple_T2OO cpy_r_r66;
+    tuple_T2OO cpy_r_r67;
     cpy_r_r0 = CPyStatic_numeric____unsigned_fixed_bounds_cache;
     if (likely(cpy_r_r0 != NULL)) goto CPyL3;
     PyErr_SetString(PyExc_NameError, "value for final name \"_unsigned_fixed_bounds_cache\" was not set");
     cpy_r_r1 = 0;
     if (unlikely(!cpy_r_r1)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 57, CPyStatic_numeric___globals);
-        goto CPyL56;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 56, CPyStatic_numeric___globals);
+        goto CPyL53;
     }
     CPy_Unreachable();
 CPyL3: ;
@@ -11632,404 +11641,388 @@ CPyL3: ;
     cpy_r_r4 = CPyDict_GetWithNone(cpy_r_r0, cpy_r_r3);
     CPy_DECREF(cpy_r_r3);
     if (unlikely(cpy_r_r4 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 57, CPyStatic_numeric___globals);
-        goto CPyL56;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 56, CPyStatic_numeric___globals);
+        goto CPyL53;
     }
     cpy_r_upper = cpy_r_r4;
     cpy_r_r5 = (PyObject *)&_Py_NoneStruct;
     cpy_r_r6 = cpy_r_upper == cpy_r_r5;
-    if (!cpy_r_r6) goto CPyL52;
-    cpy_r_r7 = CPyTagged_Subtract(cpy_r_num_bits, 2);
-    cpy_r_r8 = CPyStatics[229]; /* 2 */
-    cpy_r_r9 = CPyTagged_StealAsObject(cpy_r_r7);
-    cpy_r_r10 = CPyNumber_Power(cpy_r_r8, cpy_r_r9);
-    CPy_DECREF(cpy_r_r9);
-    if (unlikely(cpy_r_r10 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 59, CPyStatic_numeric___globals);
-        goto CPyL57;
+    if (!cpy_r_r6) goto CPyL49;
+    cpy_r_r7 = CPyDef_numeric___compute_unsigned_integer_bounds(cpy_r_num_bits);
+    if (unlikely(cpy_r_r7.f0 == CPY_INT_TAG)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 58, CPyStatic_numeric___globals);
+        goto CPyL54;
     }
-    cpy_r_r11 = CPyStatics[230]; /* 1 */
-    cpy_r_r12 = PyNumber_Subtract(cpy_r_r10, cpy_r_r11);
-    CPy_DECREF(cpy_r_r10);
-    if (unlikely(cpy_r_r12 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 59, CPyStatic_numeric___globals);
-        goto CPyL57;
+    cpy_r_r8 = cpy_r_r7.f1;
+    CPyTagged_INCREF(cpy_r_r8);
+    CPyTagged_DECREF(cpy_r_r7.f0);
+    CPyTagged_DECREF(cpy_r_r7.f1);
+    cpy_r_r9 = CPyStatic_numeric___abi_decimal_context;
+    if (unlikely(cpy_r_r9 == NULL)) {
+        goto CPyL55;
+    } else
+        goto CPyL9;
+CPyL7: ;
+    PyErr_SetString(PyExc_NameError, "value for final name \"abi_decimal_context\" was not set");
+    cpy_r_r10 = 0;
+    if (unlikely(!cpy_r_r10)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 60, CPyStatic_numeric___globals);
+        goto CPyL53;
     }
-    cpy_r_r13 = CPyStatic_numeric___abi_decimal_context;
+    CPy_Unreachable();
+CPyL9: ;
+    cpy_r_r11 = CPyModule_decimal;
+    cpy_r_r12 = CPyStatics[187]; /* 'localcontext' */
+    cpy_r_r13 = CPyObject_GetAttr(cpy_r_r11, cpy_r_r12);
     if (unlikely(cpy_r_r13 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 60, CPyStatic_numeric___globals);
+        goto CPyL56;
+    }
+    PyObject *cpy_r_r14[1] = {cpy_r_r9};
+    cpy_r_r15 = (PyObject **)&cpy_r_r14;
+    cpy_r_r16 = PyObject_Vectorcall(cpy_r_r13, cpy_r_r15, 1, 0);
+    CPy_DECREF(cpy_r_r13);
+    if (unlikely(cpy_r_r16 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 60, CPyStatic_numeric___globals);
+        goto CPyL56;
+    }
+    cpy_r_r17 = CPy_TYPE(cpy_r_r16);
+    cpy_r_r18 = CPyStatics[188]; /* '__exit__' */
+    cpy_r_r19 = CPyObject_GetAttr(cpy_r_r17, cpy_r_r18);
+    if (unlikely(cpy_r_r19 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 60, CPyStatic_numeric___globals);
+        goto CPyL57;
+    }
+    cpy_r_r20 = CPyStatics[189]; /* '__enter__' */
+    cpy_r_r21 = CPyObject_GetAttr(cpy_r_r17, cpy_r_r20);
+    CPy_DECREF(cpy_r_r17);
+    if (unlikely(cpy_r_r21 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 60, CPyStatic_numeric___globals);
+        goto CPyL58;
+    }
+    PyObject *cpy_r_r22[1] = {cpy_r_r16};
+    cpy_r_r23 = (PyObject **)&cpy_r_r22;
+    cpy_r_r24 = PyObject_Vectorcall(cpy_r_r21, cpy_r_r23, 1, 0);
+    CPy_DECREF(cpy_r_r21);
+    if (unlikely(cpy_r_r24 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 60, CPyStatic_numeric___globals);
         goto CPyL58;
     } else
-        goto CPyL10;
-CPyL8: ;
-    PyErr_SetString(PyExc_NameError, "value for final name \"abi_decimal_context\" was not set");
-    cpy_r_r14 = 0;
-    if (unlikely(!cpy_r_r14)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 61, CPyStatic_numeric___globals);
-        goto CPyL56;
-    }
-    CPy_Unreachable();
-CPyL10: ;
-    cpy_r_r15 = CPyStatic_numeric___decimal_localcontext;
-    if (unlikely(cpy_r_r15 == NULL)) {
         goto CPyL59;
-    } else
-        goto CPyL13;
-CPyL11: ;
-    PyErr_SetString(PyExc_NameError, "value for final name \"decimal_localcontext\" was not set");
-    cpy_r_r16 = 0;
-    if (unlikely(!cpy_r_r16)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 61, CPyStatic_numeric___globals);
-        goto CPyL56;
-    }
-    CPy_Unreachable();
-CPyL13: ;
-    PyObject *cpy_r_r17[1] = {cpy_r_r13};
-    cpy_r_r18 = (PyObject **)&cpy_r_r17;
-    cpy_r_r19 = PyObject_Vectorcall(cpy_r_r15, cpy_r_r18, 1, 0);
-    if (unlikely(cpy_r_r19 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 61, CPyStatic_numeric___globals);
+CPyL14: ;
+    cpy_r_r25 = 1;
+    cpy_r_r26 = CPyStatic_numeric___Decimal;
+    if (unlikely(cpy_r_r26 == NULL)) {
         goto CPyL60;
-    }
-    cpy_r_r20 = CPy_TYPE(cpy_r_r19);
-    cpy_r_r21 = CPyStatics[187]; /* '__exit__' */
-    cpy_r_r22 = CPyObject_GetAttr(cpy_r_r20, cpy_r_r21);
-    if (unlikely(cpy_r_r22 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 61, CPyStatic_numeric___globals);
-        goto CPyL61;
-    }
-    cpy_r_r23 = CPyStatics[188]; /* '__enter__' */
-    cpy_r_r24 = CPyObject_GetAttr(cpy_r_r20, cpy_r_r23);
-    CPy_DECREF(cpy_r_r20);
-    if (unlikely(cpy_r_r24 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 61, CPyStatic_numeric___globals);
-        goto CPyL62;
-    }
-    PyObject *cpy_r_r25[1] = {cpy_r_r19};
-    cpy_r_r26 = (PyObject **)&cpy_r_r25;
-    cpy_r_r27 = PyObject_Vectorcall(cpy_r_r24, cpy_r_r26, 1, 0);
-    CPy_DECREF(cpy_r_r24);
-    if (unlikely(cpy_r_r27 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 61, CPyStatic_numeric___globals);
-        goto CPyL62;
     } else
-        goto CPyL63;
-CPyL17: ;
-    cpy_r_r28 = 1;
-    cpy_r_r29 = CPyStatic_numeric___Decimal;
-    if (unlikely(cpy_r_r29 == NULL)) {
-        goto CPyL64;
-    } else
-        goto CPyL21;
-CPyL19: ;
+        goto CPyL18;
+CPyL16: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"Decimal\" was not set");
-    cpy_r_r30 = 0;
-    if (unlikely(!cpy_r_r30)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 62, CPyStatic_numeric___globals);
-        goto CPyL28;
-    } else
-        goto CPyL65;
-CPyL20: ;
-    CPy_Unreachable();
-CPyL21: ;
-    PyObject *cpy_r_r31[1] = {cpy_r_r12};
-    cpy_r_r32 = (PyObject **)&cpy_r_r31;
-    cpy_r_r33 = PyObject_Vectorcall(cpy_r_r29, cpy_r_r32, 1, 0);
-    if (unlikely(cpy_r_r33 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 62, CPyStatic_numeric___globals);
-        goto CPyL66;
-    }
-    CPy_DECREF(cpy_r_r12);
-    cpy_r_r34 = CPyStatic_numeric___TEN;
-    if (unlikely(cpy_r_r34 == NULL)) {
-        goto CPyL67;
-    } else
+    cpy_r_r27 = 0;
+    if (unlikely(!cpy_r_r27)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 61, CPyStatic_numeric___globals);
         goto CPyL25;
-CPyL23: ;
-    PyErr_SetString(PyExc_NameError, "value for final name \"TEN\" was not set");
-    cpy_r_r35 = 0;
-    if (unlikely(!cpy_r_r35)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 62, CPyStatic_numeric___globals);
-        goto CPyL28;
     } else
-        goto CPyL68;
-CPyL24: ;
+        goto CPyL61;
+CPyL17: ;
     CPy_Unreachable();
-CPyL25: ;
-    cpy_r_r36 = CPyTagged_Negate(cpy_r_frac_places);
-    cpy_r_r37 = CPyTagged_StealAsObject(cpy_r_r36);
-    cpy_r_r38 = CPyNumber_Power(cpy_r_r34, cpy_r_r37);
-    CPy_DECREF(cpy_r_r37);
-    if (unlikely(cpy_r_r38 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 62, CPyStatic_numeric___globals);
-        goto CPyL69;
+CPyL18: ;
+    cpy_r_r28 = CPyTagged_StealAsObject(cpy_r_r8);
+    PyObject *cpy_r_r29[1] = {cpy_r_r28};
+    cpy_r_r30 = (PyObject **)&cpy_r_r29;
+    cpy_r_r31 = PyObject_Vectorcall(cpy_r_r26, cpy_r_r30, 1, 0);
+    if (unlikely(cpy_r_r31 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 61, CPyStatic_numeric___globals);
+        goto CPyL62;
     }
-    cpy_r_r39 = PyNumber_Multiply(cpy_r_r33, cpy_r_r38);
-    CPy_DECREF(cpy_r_r33);
-    CPy_DECREF(cpy_r_r38);
-    if (unlikely(cpy_r_r39 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 62, CPyStatic_numeric___globals);
-        goto CPyL28;
+    CPy_DECREF(cpy_r_r28);
+    cpy_r_r32 = CPyStatic_numeric___TEN;
+    if (unlikely(cpy_r_r32 == NULL)) {
+        goto CPyL63;
     } else
-        goto CPyL70;
-CPyL27: ;
-    cpy_r_upper = cpy_r_r39;
-    goto CPyL36;
-CPyL28: ;
-    cpy_r_r40 = CPy_CatchError();
-    cpy_r_r28 = 0;
-    cpy_r_r41 = CPy_GetExcInfo();
-    cpy_r_r42 = cpy_r_r41.f0;
+        goto CPyL22;
+CPyL20: ;
+    PyErr_SetString(PyExc_NameError, "value for final name \"TEN\" was not set");
+    cpy_r_r33 = 0;
+    if (unlikely(!cpy_r_r33)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 61, CPyStatic_numeric___globals);
+        goto CPyL25;
+    } else
+        goto CPyL64;
+CPyL21: ;
+    CPy_Unreachable();
+CPyL22: ;
+    cpy_r_r34 = CPyTagged_Negate(cpy_r_frac_places);
+    cpy_r_r35 = CPyTagged_StealAsObject(cpy_r_r34);
+    cpy_r_r36 = CPyNumber_Power(cpy_r_r32, cpy_r_r35);
+    CPy_DECREF(cpy_r_r35);
+    if (unlikely(cpy_r_r36 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 61, CPyStatic_numeric___globals);
+        goto CPyL65;
+    }
+    cpy_r_r37 = PyNumber_Multiply(cpy_r_r31, cpy_r_r36);
+    CPy_DECREF(cpy_r_r31);
+    CPy_DECREF(cpy_r_r36);
+    if (unlikely(cpy_r_r37 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 61, CPyStatic_numeric___globals);
+        goto CPyL25;
+    } else
+        goto CPyL66;
+CPyL24: ;
+    cpy_r_upper = cpy_r_r37;
+    goto CPyL33;
+CPyL25: ;
+    cpy_r_r38 = CPy_CatchError();
+    cpy_r_r25 = 0;
+    cpy_r_r39 = CPy_GetExcInfo();
+    cpy_r_r40 = cpy_r_r39.f0;
+    CPy_INCREF(cpy_r_r40);
+    cpy_r_r41 = cpy_r_r39.f1;
+    CPy_INCREF(cpy_r_r41);
+    cpy_r_r42 = cpy_r_r39.f2;
     CPy_INCREF(cpy_r_r42);
-    cpy_r_r43 = cpy_r_r41.f1;
-    CPy_INCREF(cpy_r_r43);
-    cpy_r_r44 = cpy_r_r41.f2;
-    CPy_INCREF(cpy_r_r44);
-    CPy_DecRef(cpy_r_r41.f0);
-    CPy_DecRef(cpy_r_r41.f1);
-    CPy_DecRef(cpy_r_r41.f2);
-    PyObject *cpy_r_r45[4] = {cpy_r_r19, cpy_r_r42, cpy_r_r43, cpy_r_r44};
-    cpy_r_r46 = (PyObject **)&cpy_r_r45;
-    cpy_r_r47 = PyObject_Vectorcall(cpy_r_r22, cpy_r_r46, 4, 0);
-    if (unlikely(cpy_r_r47 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 61, CPyStatic_numeric___globals);
-        goto CPyL71;
+    CPy_DecRef(cpy_r_r39.f0);
+    CPy_DecRef(cpy_r_r39.f1);
+    CPy_DecRef(cpy_r_r39.f2);
+    PyObject *cpy_r_r43[4] = {cpy_r_r16, cpy_r_r40, cpy_r_r41, cpy_r_r42};
+    cpy_r_r44 = (PyObject **)&cpy_r_r43;
+    cpy_r_r45 = PyObject_Vectorcall(cpy_r_r19, cpy_r_r44, 4, 0);
+    if (unlikely(cpy_r_r45 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 60, CPyStatic_numeric___globals);
+        goto CPyL67;
     }
+    CPy_DecRef(cpy_r_r40);
+    CPy_DecRef(cpy_r_r41);
     CPy_DecRef(cpy_r_r42);
-    CPy_DecRef(cpy_r_r43);
-    CPy_DecRef(cpy_r_r44);
-    cpy_r_r48 = PyObject_IsTrue(cpy_r_r47);
-    CPy_DecRef(cpy_r_r47);
-    cpy_r_r49 = cpy_r_r48 >= 0;
-    if (unlikely(!cpy_r_r49)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 61, CPyStatic_numeric___globals);
-        goto CPyL34;
+    cpy_r_r46 = PyObject_IsTrue(cpy_r_r45);
+    CPy_DecRef(cpy_r_r45);
+    cpy_r_r47 = cpy_r_r46 >= 0;
+    if (unlikely(!cpy_r_r47)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 60, CPyStatic_numeric___globals);
+        goto CPyL31;
     }
-    cpy_r_r50 = cpy_r_r48;
-    if (cpy_r_r50) goto CPyL33;
+    cpy_r_r48 = cpy_r_r46;
+    if (cpy_r_r48) goto CPyL30;
     CPy_Reraise();
     if (!0) {
+        goto CPyL31;
+    } else
+        goto CPyL68;
+CPyL29: ;
+    CPy_Unreachable();
+CPyL30: ;
+    CPy_RestoreExcInfo(cpy_r_r38);
+    CPy_DecRef(cpy_r_r38.f0);
+    CPy_DecRef(cpy_r_r38.f1);
+    CPy_DecRef(cpy_r_r38.f2);
+    goto CPyL33;
+CPyL31: ;
+    CPy_RestoreExcInfo(cpy_r_r38);
+    CPy_DecRef(cpy_r_r38.f0);
+    CPy_DecRef(cpy_r_r38.f1);
+    CPy_DecRef(cpy_r_r38.f2);
+    cpy_r_r49 = CPy_KeepPropagating();
+    if (!cpy_r_r49) {
         goto CPyL34;
     } else
-        goto CPyL72;
+        goto CPyL69;
 CPyL32: ;
     CPy_Unreachable();
 CPyL33: ;
-    CPy_RestoreExcInfo(cpy_r_r40);
-    CPy_DecRef(cpy_r_r40.f0);
-    CPy_DecRef(cpy_r_r40.f1);
-    CPy_DecRef(cpy_r_r40.f2);
-    goto CPyL36;
+    tuple_T3OOO __tmp65 = { NULL, NULL, NULL };
+    cpy_r_r50 = __tmp65;
+    cpy_r_r51 = cpy_r_r50;
+    goto CPyL35;
 CPyL34: ;
-    CPy_RestoreExcInfo(cpy_r_r40);
-    CPy_DecRef(cpy_r_r40.f0);
-    CPy_DecRef(cpy_r_r40.f1);
-    CPy_DecRef(cpy_r_r40.f2);
-    cpy_r_r51 = CPy_KeepPropagating();
-    if (!cpy_r_r51) {
-        goto CPyL37;
+    cpy_r_r52 = CPy_CatchError();
+    cpy_r_r51 = cpy_r_r52;
+CPyL35: ;
+    if (!cpy_r_r25) goto CPyL70;
+    cpy_r_r53 = (PyObject *)&_Py_NoneStruct;
+    PyObject *cpy_r_r54[4] = {cpy_r_r16, cpy_r_r53, cpy_r_r53, cpy_r_r53};
+    cpy_r_r55 = (PyObject **)&cpy_r_r54;
+    cpy_r_r56 = PyObject_Vectorcall(cpy_r_r19, cpy_r_r55, 4, 0);
+    CPy_DECREF(cpy_r_r19);
+    if (unlikely(cpy_r_r56 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 60, CPyStatic_numeric___globals);
+        goto CPyL71;
+    } else
+        goto CPyL72;
+CPyL37: ;
+    CPy_DECREF(cpy_r_r16);
+CPyL38: ;
+    if (cpy_r_r51.f0 == NULL) {
+        goto CPyL45;
     } else
         goto CPyL73;
-CPyL35: ;
-    CPy_Unreachable();
-CPyL36: ;
-    tuple_T3OOO __tmp65 = { NULL, NULL, NULL };
-    cpy_r_r52 = __tmp65;
-    cpy_r_r53 = cpy_r_r52;
-    goto CPyL38;
-CPyL37: ;
-    cpy_r_r54 = CPy_CatchError();
-    cpy_r_r53 = cpy_r_r54;
-CPyL38: ;
-    if (!cpy_r_r28) goto CPyL74;
-    cpy_r_r55 = (PyObject *)&_Py_NoneStruct;
-    PyObject *cpy_r_r56[4] = {cpy_r_r19, cpy_r_r55, cpy_r_r55, cpy_r_r55};
-    cpy_r_r57 = (PyObject **)&cpy_r_r56;
-    cpy_r_r58 = PyObject_Vectorcall(cpy_r_r22, cpy_r_r57, 4, 0);
-    CPy_DECREF(cpy_r_r22);
-    if (unlikely(cpy_r_r58 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 61, CPyStatic_numeric___globals);
-        goto CPyL75;
-    } else
-        goto CPyL76;
-CPyL40: ;
-    CPy_DECREF(cpy_r_r19);
-CPyL41: ;
-    if (cpy_r_r53.f0 == NULL) {
-        goto CPyL48;
-    } else
-        goto CPyL77;
-CPyL42: ;
+CPyL39: ;
     CPy_Reraise();
     if (!0) {
-        goto CPyL44;
+        goto CPyL41;
     } else
-        goto CPyL78;
-CPyL43: ;
+        goto CPyL74;
+CPyL40: ;
     CPy_Unreachable();
-CPyL44: ;
-    if (cpy_r_r53.f0 == NULL) goto CPyL46;
-    CPy_RestoreExcInfo(cpy_r_r53);
-    CPy_XDECREF(cpy_r_r53.f0);
-    CPy_XDECREF(cpy_r_r53.f1);
-    CPy_XDECREF(cpy_r_r53.f2);
+CPyL41: ;
+    if (cpy_r_r51.f0 == NULL) goto CPyL43;
+    CPy_RestoreExcInfo(cpy_r_r51);
+    CPy_XDECREF(cpy_r_r51.f0);
+    CPy_XDECREF(cpy_r_r51.f1);
+    CPy_XDECREF(cpy_r_r51.f2);
+CPyL43: ;
+    cpy_r_r57 = CPy_KeepPropagating();
+    if (!cpy_r_r57) goto CPyL53;
+    CPy_Unreachable();
+CPyL45: ;
+    cpy_r_r58 = CPyStatic_numeric____unsigned_fixed_bounds_cache;
+    if (unlikely(cpy_r_r58 == NULL)) {
+        goto CPyL75;
+    } else
+        goto CPyL48;
 CPyL46: ;
-    cpy_r_r59 = CPy_KeepPropagating();
-    if (!cpy_r_r59) goto CPyL56;
+    PyErr_SetString(PyExc_NameError, "value for final name \"_unsigned_fixed_bounds_cache\" was not set");
+    cpy_r_r59 = 0;
+    if (unlikely(!cpy_r_r59)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 63, CPyStatic_numeric___globals);
+        goto CPyL53;
+    }
     CPy_Unreachable();
 CPyL48: ;
-    cpy_r_r60 = CPyStatic_numeric____unsigned_fixed_bounds_cache;
-    if (unlikely(cpy_r_r60 == NULL)) {
-        goto CPyL79;
-    } else
-        goto CPyL51;
-CPyL49: ;
-    PyErr_SetString(PyExc_NameError, "value for final name \"_unsigned_fixed_bounds_cache\" was not set");
-    cpy_r_r61 = 0;
-    if (unlikely(!cpy_r_r61)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 64, CPyStatic_numeric___globals);
-        goto CPyL56;
-    }
-    CPy_Unreachable();
-CPyL51: ;
     CPyTagged_INCREF(cpy_r_num_bits);
     CPyTagged_INCREF(cpy_r_frac_places);
-    cpy_r_r62.f0 = cpy_r_num_bits;
-    cpy_r_r62.f1 = cpy_r_frac_places;
-    cpy_r_r63 = PyTuple_New(2);
-    if (unlikely(cpy_r_r63 == NULL))
+    cpy_r_r60.f0 = cpy_r_num_bits;
+    cpy_r_r60.f1 = cpy_r_frac_places;
+    cpy_r_r61 = PyTuple_New(2);
+    if (unlikely(cpy_r_r61 == NULL))
         CPyError_OutOfMemory();
-    PyObject *__tmp66 = CPyTagged_StealAsObject(cpy_r_r62.f0);
-    PyTuple_SET_ITEM(cpy_r_r63, 0, __tmp66);
-    PyObject *__tmp67 = CPyTagged_StealAsObject(cpy_r_r62.f1);
-    PyTuple_SET_ITEM(cpy_r_r63, 1, __tmp67);
-    cpy_r_r64 = CPyDict_SetItem(cpy_r_r60, cpy_r_r63, cpy_r_upper);
-    CPy_DECREF(cpy_r_r63);
-    cpy_r_r65 = cpy_r_r64 >= 0;
-    if (unlikely(!cpy_r_r65)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 64, CPyStatic_numeric___globals);
-        goto CPyL57;
+    PyObject *__tmp66 = CPyTagged_StealAsObject(cpy_r_r60.f0);
+    PyTuple_SET_ITEM(cpy_r_r61, 0, __tmp66);
+    PyObject *__tmp67 = CPyTagged_StealAsObject(cpy_r_r60.f1);
+    PyTuple_SET_ITEM(cpy_r_r61, 1, __tmp67);
+    cpy_r_r62 = CPyDict_SetItem(cpy_r_r58, cpy_r_r61, cpy_r_upper);
+    CPy_DECREF(cpy_r_r61);
+    cpy_r_r63 = cpy_r_r62 >= 0;
+    if (unlikely(!cpy_r_r63)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 63, CPyStatic_numeric___globals);
+        goto CPyL54;
     }
-CPyL52: ;
-    cpy_r_r66 = CPyStatic_numeric___ZERO;
-    if (unlikely(cpy_r_r66 == NULL)) {
-        goto CPyL80;
+CPyL49: ;
+    cpy_r_r64 = CPyStatic_numeric___ZERO;
+    if (unlikely(cpy_r_r64 == NULL)) {
+        goto CPyL76;
     } else
-        goto CPyL55;
-CPyL53: ;
+        goto CPyL52;
+CPyL50: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"ZERO\" was not set");
-    cpy_r_r67 = 0;
-    if (unlikely(!cpy_r_r67)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 66, CPyStatic_numeric___globals);
-        goto CPyL56;
+    cpy_r_r65 = 0;
+    if (unlikely(!cpy_r_r65)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 65, CPyStatic_numeric___globals);
+        goto CPyL53;
     }
     CPy_Unreachable();
-CPyL55: ;
-    CPy_INCREF(cpy_r_r66);
-    cpy_r_r68.f0 = cpy_r_r66;
-    cpy_r_r68.f1 = cpy_r_upper;
-    return cpy_r_r68;
-CPyL56: ;
+CPyL52: ;
+    CPy_INCREF(cpy_r_r64);
+    cpy_r_r66.f0 = cpy_r_r64;
+    cpy_r_r66.f1 = cpy_r_upper;
+    return cpy_r_r66;
+CPyL53: ;
     tuple_T2OO __tmp68 = { NULL, NULL };
-    cpy_r_r69 = __tmp68;
-    return cpy_r_r69;
-CPyL57: ;
-    CPy_DecRef(cpy_r_upper);
-    goto CPyL56;
-CPyL58: ;
-    CPy_DecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r12);
-    goto CPyL8;
-CPyL59: ;
-    CPy_DecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r12);
-    goto CPyL11;
-CPyL60: ;
-    CPy_DecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r12);
-    goto CPyL56;
-CPyL61: ;
-    CPy_DecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r12);
-    CPy_DecRef(cpy_r_r19);
-    CPy_DecRef(cpy_r_r20);
-    goto CPyL56;
-CPyL62: ;
-    CPy_DecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r12);
-    CPy_DecRef(cpy_r_r19);
-    CPy_DecRef(cpy_r_r22);
-    goto CPyL56;
-CPyL63: ;
-    CPy_DECREF(cpy_r_r27);
-    goto CPyL17;
-CPyL64: ;
-    CPy_DecRef(cpy_r_r12);
-    goto CPyL19;
-CPyL65: ;
-    CPy_DecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r19);
-    CPy_DecRef(cpy_r_r22);
-    goto CPyL20;
-CPyL66: ;
-    CPy_DecRef(cpy_r_r12);
-    goto CPyL28;
-CPyL67: ;
-    CPy_DecRef(cpy_r_r33);
-    goto CPyL23;
-CPyL68: ;
-    CPy_DecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r19);
-    CPy_DecRef(cpy_r_r22);
-    goto CPyL24;
-CPyL69: ;
-    CPy_DecRef(cpy_r_r33);
-    goto CPyL28;
-CPyL70: ;
-    CPy_DECREF(cpy_r_upper);
-    goto CPyL27;
-CPyL71: ;
-    CPy_DecRef(cpy_r_r42);
-    CPy_DecRef(cpy_r_r43);
-    CPy_DecRef(cpy_r_r44);
-    goto CPyL34;
-CPyL72: ;
-    CPy_DecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r19);
-    CPy_DecRef(cpy_r_r22);
-    CPy_DecRef(cpy_r_r40.f0);
-    CPy_DecRef(cpy_r_r40.f1);
-    CPy_DecRef(cpy_r_r40.f2);
-    goto CPyL32;
-CPyL73: ;
-    CPy_DecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r19);
-    CPy_DecRef(cpy_r_r22);
-    goto CPyL35;
-CPyL74: ;
-    CPy_DECREF(cpy_r_r19);
-    CPy_DECREF(cpy_r_r22);
-    goto CPyL41;
-CPyL75: ;
-    CPy_DecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r19);
-    goto CPyL44;
-CPyL76: ;
-    CPy_DECREF(cpy_r_r58);
-    goto CPyL40;
-CPyL77: ;
-    CPy_DECREF(cpy_r_upper);
-    goto CPyL42;
-CPyL78: ;
-    CPy_XDECREF(cpy_r_r53.f0);
-    CPy_XDECREF(cpy_r_r53.f1);
-    CPy_XDECREF(cpy_r_r53.f2);
-    goto CPyL43;
-CPyL79: ;
-    CPy_DecRef(cpy_r_upper);
-    goto CPyL49;
-CPyL80: ;
+    cpy_r_r67 = __tmp68;
+    return cpy_r_r67;
+CPyL54: ;
     CPy_DecRef(cpy_r_upper);
     goto CPyL53;
+CPyL55: ;
+    CPy_DecRef(cpy_r_upper);
+    CPyTagged_DecRef(cpy_r_r8);
+    goto CPyL7;
+CPyL56: ;
+    CPy_DecRef(cpy_r_upper);
+    CPyTagged_DecRef(cpy_r_r8);
+    goto CPyL53;
+CPyL57: ;
+    CPy_DecRef(cpy_r_upper);
+    CPyTagged_DecRef(cpy_r_r8);
+    CPy_DecRef(cpy_r_r16);
+    CPy_DecRef(cpy_r_r17);
+    goto CPyL53;
+CPyL58: ;
+    CPy_DecRef(cpy_r_upper);
+    CPyTagged_DecRef(cpy_r_r8);
+    CPy_DecRef(cpy_r_r16);
+    CPy_DecRef(cpy_r_r19);
+    goto CPyL53;
+CPyL59: ;
+    CPy_DECREF(cpy_r_r24);
+    goto CPyL14;
+CPyL60: ;
+    CPyTagged_DecRef(cpy_r_r8);
+    goto CPyL16;
+CPyL61: ;
+    CPy_DecRef(cpy_r_upper);
+    CPy_DecRef(cpy_r_r16);
+    CPy_DecRef(cpy_r_r19);
+    goto CPyL17;
+CPyL62: ;
+    CPy_DecRef(cpy_r_r28);
+    goto CPyL25;
+CPyL63: ;
+    CPy_DecRef(cpy_r_r31);
+    goto CPyL20;
+CPyL64: ;
+    CPy_DecRef(cpy_r_upper);
+    CPy_DecRef(cpy_r_r16);
+    CPy_DecRef(cpy_r_r19);
+    goto CPyL21;
+CPyL65: ;
+    CPy_DecRef(cpy_r_r31);
+    goto CPyL25;
+CPyL66: ;
+    CPy_DECREF(cpy_r_upper);
+    goto CPyL24;
+CPyL67: ;
+    CPy_DecRef(cpy_r_r40);
+    CPy_DecRef(cpy_r_r41);
+    CPy_DecRef(cpy_r_r42);
+    goto CPyL31;
+CPyL68: ;
+    CPy_DecRef(cpy_r_upper);
+    CPy_DecRef(cpy_r_r16);
+    CPy_DecRef(cpy_r_r19);
+    CPy_DecRef(cpy_r_r38.f0);
+    CPy_DecRef(cpy_r_r38.f1);
+    CPy_DecRef(cpy_r_r38.f2);
+    goto CPyL29;
+CPyL69: ;
+    CPy_DecRef(cpy_r_upper);
+    CPy_DecRef(cpy_r_r16);
+    CPy_DecRef(cpy_r_r19);
+    goto CPyL32;
+CPyL70: ;
+    CPy_DECREF(cpy_r_r16);
+    CPy_DECREF(cpy_r_r19);
+    goto CPyL38;
+CPyL71: ;
+    CPy_DecRef(cpy_r_upper);
+    CPy_DecRef(cpy_r_r16);
+    goto CPyL41;
+CPyL72: ;
+    CPy_DECREF(cpy_r_r56);
+    goto CPyL37;
+CPyL73: ;
+    CPy_DECREF(cpy_r_upper);
+    goto CPyL39;
+CPyL74: ;
+    CPy_XDECREF(cpy_r_r51.f0);
+    CPy_XDECREF(cpy_r_r51.f1);
+    CPy_XDECREF(cpy_r_r51.f2);
+    goto CPyL40;
+CPyL75: ;
+    CPy_DecRef(cpy_r_upper);
+    goto CPyL46;
+CPyL76: ;
+    CPy_DecRef(cpy_r_upper);
+    goto CPyL50;
 }
 
 PyObject *CPyPy_numeric___compute_unsigned_fixed_bounds(PyObject *self, PyObject *const *args, size_t nargs, PyObject *kwnames) {
@@ -12065,7 +12058,7 @@ PyObject *CPyPy_numeric___compute_unsigned_fixed_bounds(PyObject *self, PyObject
     PyTuple_SET_ITEM(retbox, 1, __tmp70);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 53, CPyStatic_numeric___globals);
+    CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_unsigned_fixed_bounds", 52, CPyStatic_numeric___globals);
     return NULL;
 }
 
@@ -12091,81 +12084,82 @@ tuple_T2OO CPyDef_numeric___compute_signed_fixed_bounds(CPyTagged cpy_r_num_bits
     PyObject *cpy_r_r15;
     char cpy_r_r16;
     PyObject *cpy_r_r17;
-    char cpy_r_r18;
-    PyObject **cpy_r_r20;
-    PyObject *cpy_r_r21;
+    PyObject *cpy_r_r18;
+    PyObject *cpy_r_r19;
+    PyObject **cpy_r_r21;
     PyObject *cpy_r_r22;
     PyObject *cpy_r_r23;
     PyObject *cpy_r_r24;
     PyObject *cpy_r_r25;
     PyObject *cpy_r_r26;
-    PyObject **cpy_r_r28;
-    PyObject *cpy_r_r29;
-    char cpy_r_r30;
-    PyObject *cpy_r_r31;
-    char cpy_r_r32;
-    CPyTagged cpy_r_r33;
-    PyObject *cpy_r_r34;
+    PyObject *cpy_r_r27;
+    PyObject **cpy_r_r29;
+    PyObject *cpy_r_r30;
+    char cpy_r_r31;
+    PyObject *cpy_r_r32;
+    char cpy_r_r33;
+    CPyTagged cpy_r_r34;
     PyObject *cpy_r_r35;
     PyObject *cpy_r_r36;
-    char cpy_r_r37;
-    PyObject *cpy_r_r38;
-    PyObject **cpy_r_r40;
-    PyObject *cpy_r_r41;
+    PyObject *cpy_r_r37;
+    char cpy_r_r38;
+    PyObject *cpy_r_r39;
+    PyObject **cpy_r_r41;
     PyObject *cpy_r_r42;
     PyObject *cpy_r_r43;
-    char cpy_r_r44;
-    PyObject *cpy_r_r45;
-    PyObject **cpy_r_r47;
-    PyObject *cpy_r_r48;
+    PyObject *cpy_r_r44;
+    char cpy_r_r45;
+    PyObject *cpy_r_r46;
+    PyObject **cpy_r_r48;
     PyObject *cpy_r_r49;
-    tuple_T3OOO cpy_r_r50;
+    PyObject *cpy_r_r50;
     tuple_T3OOO cpy_r_r51;
-    PyObject *cpy_r_r52;
+    tuple_T3OOO cpy_r_r52;
     PyObject *cpy_r_r53;
     PyObject *cpy_r_r54;
-    PyObject **cpy_r_r56;
-    PyObject *cpy_r_r57;
-    int32_t cpy_r_r58;
-    char cpy_r_r59;
+    PyObject *cpy_r_r55;
+    PyObject **cpy_r_r57;
+    PyObject *cpy_r_r58;
+    int32_t cpy_r_r59;
     char cpy_r_r60;
     char cpy_r_r61;
-    tuple_T3OOO cpy_r_r62;
+    char cpy_r_r62;
     tuple_T3OOO cpy_r_r63;
     tuple_T3OOO cpy_r_r64;
-    PyObject *cpy_r_r65;
-    PyObject **cpy_r_r67;
-    PyObject *cpy_r_r68;
-    char cpy_r_r69;
+    tuple_T3OOO cpy_r_r65;
+    PyObject *cpy_r_r66;
+    PyObject **cpy_r_r68;
+    PyObject *cpy_r_r69;
     char cpy_r_r70;
     char cpy_r_r71;
-    tuple_T2OO cpy_r_r72;
-    PyObject *cpy_r_r73;
-    tuple_T2OO cpy_r_r74;
-    PyObject *cpy_r_r75;
-    char cpy_r_r76;
-    tuple_T2II cpy_r_r77;
-    PyObject *cpy_r_r78;
+    char cpy_r_r72;
+    tuple_T2OO cpy_r_r73;
+    PyObject *cpy_r_r74;
+    tuple_T2OO cpy_r_r75;
+    PyObject *cpy_r_r76;
+    char cpy_r_r77;
+    tuple_T2II cpy_r_r78;
     PyObject *cpy_r_r79;
-    int32_t cpy_r_r80;
-    char cpy_r_r81;
-    tuple_T2OO cpy_r_r82;
+    PyObject *cpy_r_r80;
+    int32_t cpy_r_r81;
+    char cpy_r_r82;
     tuple_T2OO cpy_r_r83;
+    tuple_T2OO cpy_r_r84;
     cpy_r_r0 = NULL;
     cpy_r_lower = cpy_r_r0;
     cpy_r_r1 = NULL;
     cpy_r_upper = cpy_r_r1;
     cpy_r_r2 = CPyStatic_numeric____signed_fixed_bounds_cache;
     if (unlikely(cpy_r_r2 == NULL)) {
-        goto CPyL67;
+        goto CPyL65;
     } else
         goto CPyL3;
 CPyL1: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"_signed_fixed_bounds_cache\" was not set");
     cpy_r_r3 = 0;
     if (unlikely(!cpy_r_r3)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 76, CPyStatic_numeric___globals);
-        goto CPyL66;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 77, CPyStatic_numeric___globals);
+        goto CPyL64;
     }
     CPy_Unreachable();
 CPyL3: ;
@@ -12183,8 +12177,8 @@ CPyL3: ;
     cpy_r_r6 = CPyDict_GetWithNone(cpy_r_r2, cpy_r_r5);
     CPy_DECREF(cpy_r_r5);
     if (unlikely(cpy_r_r6 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 76, CPyStatic_numeric___globals);
-        goto CPyL68;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 77, CPyStatic_numeric___globals);
+        goto CPyL66;
     }
     if (unlikely(!(PyTuple_Check(cpy_r_r6) && PyTuple_GET_SIZE(cpy_r_r6) == 2))) {
         cpy_r_r7 = NULL;
@@ -12203,21 +12197,21 @@ __LL74: ;
         cpy_r_r7 = NULL;
     }
     if (cpy_r_r7 != NULL) goto __LL73;
-    CPy_TypeErrorTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 76, CPyStatic_numeric___globals, "tuple[object, object] or None", cpy_r_r6);
-    goto CPyL68;
+    CPy_TypeErrorTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 77, CPyStatic_numeric___globals, "tuple[object, object] or None", cpy_r_r6);
+    goto CPyL66;
 __LL73: ;
     cpy_r_bounds = cpy_r_r7;
     cpy_r_r8 = (PyObject *)&_Py_NoneStruct;
     cpy_r_r9 = cpy_r_bounds == cpy_r_r8;
     if (cpy_r_r9) {
-        goto CPyL69;
+        goto CPyL67;
     } else
-        goto CPyL70;
+        goto CPyL68;
 CPyL6: ;
     cpy_r_r10 = CPyDef_numeric___compute_signed_integer_bounds(cpy_r_num_bits);
     if (unlikely(cpy_r_r10.f0 == CPY_INT_TAG)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 78, CPyStatic_numeric___globals);
-        goto CPyL68;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 79, CPyStatic_numeric___globals);
+        goto CPyL66;
     }
     cpy_r_r11 = cpy_r_r10.f0;
     cpy_r_r12 = cpy_r_r10.f1;
@@ -12225,297 +12219,291 @@ CPyL6: ;
     cpy_r_r14 = cpy_r_r12;
     cpy_r_r15 = CPyStatic_numeric___abi_decimal_context;
     if (unlikely(cpy_r_r15 == NULL)) {
-        goto CPyL71;
+        goto CPyL69;
     } else
         goto CPyL10;
 CPyL8: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"abi_decimal_context\" was not set");
     cpy_r_r16 = 0;
     if (unlikely(!cpy_r_r16)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 80, CPyStatic_numeric___globals);
-        goto CPyL66;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 81, CPyStatic_numeric___globals);
+        goto CPyL64;
     }
     CPy_Unreachable();
 CPyL10: ;
-    cpy_r_r17 = CPyStatic_numeric___decimal_localcontext;
-    if (unlikely(cpy_r_r17 == NULL)) {
+    cpy_r_r17 = CPyModule_decimal;
+    cpy_r_r18 = CPyStatics[187]; /* 'localcontext' */
+    cpy_r_r19 = CPyObject_GetAttr(cpy_r_r17, cpy_r_r18);
+    if (unlikely(cpy_r_r19 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 81, CPyStatic_numeric___globals);
+        goto CPyL70;
+    }
+    PyObject *cpy_r_r20[1] = {cpy_r_r15};
+    cpy_r_r21 = (PyObject **)&cpy_r_r20;
+    cpy_r_r22 = PyObject_Vectorcall(cpy_r_r19, cpy_r_r21, 1, 0);
+    CPy_DECREF(cpy_r_r19);
+    if (unlikely(cpy_r_r22 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 81, CPyStatic_numeric___globals);
+        goto CPyL70;
+    }
+    cpy_r_r23 = CPy_TYPE(cpy_r_r22);
+    cpy_r_r24 = CPyStatics[188]; /* '__exit__' */
+    cpy_r_r25 = CPyObject_GetAttr(cpy_r_r23, cpy_r_r24);
+    if (unlikely(cpy_r_r25 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 81, CPyStatic_numeric___globals);
+        goto CPyL71;
+    }
+    cpy_r_r26 = CPyStatics[189]; /* '__enter__' */
+    cpy_r_r27 = CPyObject_GetAttr(cpy_r_r23, cpy_r_r26);
+    CPy_DECREF(cpy_r_r23);
+    if (unlikely(cpy_r_r27 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 81, CPyStatic_numeric___globals);
+        goto CPyL72;
+    }
+    PyObject *cpy_r_r28[1] = {cpy_r_r22};
+    cpy_r_r29 = (PyObject **)&cpy_r_r28;
+    cpy_r_r30 = PyObject_Vectorcall(cpy_r_r27, cpy_r_r29, 1, 0);
+    CPy_DECREF(cpy_r_r27);
+    if (unlikely(cpy_r_r30 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 81, CPyStatic_numeric___globals);
         goto CPyL72;
     } else
-        goto CPyL13;
-CPyL11: ;
-    PyErr_SetString(PyExc_NameError, "value for final name \"decimal_localcontext\" was not set");
-    cpy_r_r18 = 0;
-    if (unlikely(!cpy_r_r18)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 80, CPyStatic_numeric___globals);
-        goto CPyL66;
-    }
-    CPy_Unreachable();
-CPyL13: ;
-    PyObject *cpy_r_r19[1] = {cpy_r_r15};
-    cpy_r_r20 = (PyObject **)&cpy_r_r19;
-    cpy_r_r21 = PyObject_Vectorcall(cpy_r_r17, cpy_r_r20, 1, 0);
-    if (unlikely(cpy_r_r21 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 80, CPyStatic_numeric___globals);
         goto CPyL73;
-    }
-    cpy_r_r22 = CPy_TYPE(cpy_r_r21);
-    cpy_r_r23 = CPyStatics[187]; /* '__exit__' */
-    cpy_r_r24 = CPyObject_GetAttr(cpy_r_r22, cpy_r_r23);
-    if (unlikely(cpy_r_r24 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 80, CPyStatic_numeric___globals);
+CPyL15: ;
+    cpy_r_r31 = 1;
+    cpy_r_r32 = CPyStatic_numeric___TEN;
+    if (unlikely(cpy_r_r32 == NULL)) {
         goto CPyL74;
-    }
-    cpy_r_r25 = CPyStatics[188]; /* '__enter__' */
-    cpy_r_r26 = CPyObject_GetAttr(cpy_r_r22, cpy_r_r25);
-    CPy_DECREF(cpy_r_r22);
-    if (unlikely(cpy_r_r26 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 80, CPyStatic_numeric___globals);
-        goto CPyL75;
-    }
-    PyObject *cpy_r_r27[1] = {cpy_r_r21};
-    cpy_r_r28 = (PyObject **)&cpy_r_r27;
-    cpy_r_r29 = PyObject_Vectorcall(cpy_r_r26, cpy_r_r28, 1, 0);
-    CPy_DECREF(cpy_r_r26);
-    if (unlikely(cpy_r_r29 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 80, CPyStatic_numeric___globals);
-        goto CPyL75;
     } else
-        goto CPyL76;
+        goto CPyL19;
 CPyL17: ;
-    cpy_r_r30 = 1;
-    cpy_r_r31 = CPyStatic_numeric___TEN;
-    if (unlikely(cpy_r_r31 == NULL)) {
+    PyErr_SetString(PyExc_NameError, "value for final name \"TEN\" was not set");
+    cpy_r_r33 = 0;
+    if (unlikely(!cpy_r_r33)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 82, CPyStatic_numeric___globals);
+        goto CPyL31;
+    } else
+        goto CPyL75;
+CPyL18: ;
+    CPy_Unreachable();
+CPyL19: ;
+    cpy_r_r34 = CPyTagged_Negate(cpy_r_frac_places);
+    cpy_r_r35 = CPyTagged_StealAsObject(cpy_r_r34);
+    cpy_r_r36 = CPyNumber_Power(cpy_r_r32, cpy_r_r35);
+    CPy_DECREF(cpy_r_r35);
+    if (unlikely(cpy_r_r36 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 82, CPyStatic_numeric___globals);
+        goto CPyL76;
+    }
+    cpy_r_r37 = CPyStatic_numeric___Decimal;
+    if (unlikely(cpy_r_r37 == NULL)) {
         goto CPyL77;
     } else
-        goto CPyL21;
-CPyL19: ;
-    PyErr_SetString(PyExc_NameError, "value for final name \"TEN\" was not set");
-    cpy_r_r32 = 0;
-    if (unlikely(!cpy_r_r32)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 81, CPyStatic_numeric___globals);
-        goto CPyL33;
+        goto CPyL23;
+CPyL21: ;
+    PyErr_SetString(PyExc_NameError, "value for final name \"Decimal\" was not set");
+    cpy_r_r38 = 0;
+    if (unlikely(!cpy_r_r38)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 83, CPyStatic_numeric___globals);
+        goto CPyL31;
     } else
         goto CPyL78;
-CPyL20: ;
+CPyL22: ;
     CPy_Unreachable();
-CPyL21: ;
-    cpy_r_r33 = CPyTagged_Negate(cpy_r_frac_places);
-    cpy_r_r34 = CPyTagged_StealAsObject(cpy_r_r33);
-    cpy_r_r35 = CPyNumber_Power(cpy_r_r31, cpy_r_r34);
-    CPy_DECREF(cpy_r_r34);
-    if (unlikely(cpy_r_r35 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 81, CPyStatic_numeric___globals);
+CPyL23: ;
+    cpy_r_r39 = CPyTagged_StealAsObject(cpy_r_r13);
+    PyObject *cpy_r_r40[1] = {cpy_r_r39};
+    cpy_r_r41 = (PyObject **)&cpy_r_r40;
+    cpy_r_r42 = PyObject_Vectorcall(cpy_r_r37, cpy_r_r41, 1, 0);
+    if (unlikely(cpy_r_r42 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 83, CPyStatic_numeric___globals);
         goto CPyL79;
     }
-    cpy_r_r36 = CPyStatic_numeric___Decimal;
-    if (unlikely(cpy_r_r36 == NULL)) {
+    CPy_DECREF(cpy_r_r39);
+    cpy_r_r43 = PyNumber_Multiply(cpy_r_r42, cpy_r_r36);
+    CPy_DECREF(cpy_r_r42);
+    if (unlikely(cpy_r_r43 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 83, CPyStatic_numeric___globals);
         goto CPyL80;
     } else
-        goto CPyL25;
-CPyL23: ;
-    PyErr_SetString(PyExc_NameError, "value for final name \"Decimal\" was not set");
-    cpy_r_r37 = 0;
-    if (unlikely(!cpy_r_r37)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 82, CPyStatic_numeric___globals);
-        goto CPyL33;
-    } else
         goto CPyL81;
-CPyL24: ;
-    CPy_Unreachable();
 CPyL25: ;
-    cpy_r_r38 = CPyTagged_StealAsObject(cpy_r_r13);
-    PyObject *cpy_r_r39[1] = {cpy_r_r38};
-    cpy_r_r40 = (PyObject **)&cpy_r_r39;
-    cpy_r_r41 = PyObject_Vectorcall(cpy_r_r36, cpy_r_r40, 1, 0);
-    if (unlikely(cpy_r_r41 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 82, CPyStatic_numeric___globals);
+    cpy_r_lower = cpy_r_r43;
+    cpy_r_r44 = CPyStatic_numeric___Decimal;
+    if (unlikely(cpy_r_r44 == NULL)) {
         goto CPyL82;
-    }
-    CPy_DECREF(cpy_r_r38);
-    cpy_r_r42 = PyNumber_Multiply(cpy_r_r41, cpy_r_r35);
-    CPy_DECREF(cpy_r_r41);
-    if (unlikely(cpy_r_r42 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 82, CPyStatic_numeric___globals);
-        goto CPyL83;
     } else
-        goto CPyL84;
-CPyL27: ;
-    cpy_r_lower = cpy_r_r42;
-    cpy_r_r43 = CPyStatic_numeric___Decimal;
-    if (unlikely(cpy_r_r43 == NULL)) {
-        goto CPyL85;
-    } else
-        goto CPyL30;
-CPyL28: ;
+        goto CPyL28;
+CPyL26: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"Decimal\" was not set");
-    cpy_r_r44 = 0;
-    if (unlikely(!cpy_r_r44)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 83, CPyStatic_numeric___globals);
-        goto CPyL33;
+    cpy_r_r45 = 0;
+    if (unlikely(!cpy_r_r45)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 84, CPyStatic_numeric___globals);
+        goto CPyL31;
     } else
-        goto CPyL86;
-CPyL29: ;
+        goto CPyL83;
+CPyL27: ;
     CPy_Unreachable();
-CPyL30: ;
-    cpy_r_r45 = CPyTagged_StealAsObject(cpy_r_r14);
-    PyObject *cpy_r_r46[1] = {cpy_r_r45};
-    cpy_r_r47 = (PyObject **)&cpy_r_r46;
-    cpy_r_r48 = PyObject_Vectorcall(cpy_r_r43, cpy_r_r47, 1, 0);
-    if (unlikely(cpy_r_r48 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 83, CPyStatic_numeric___globals);
-        goto CPyL87;
-    }
-    CPy_DECREF(cpy_r_r45);
-    cpy_r_r49 = PyNumber_Multiply(cpy_r_r48, cpy_r_r35);
-    CPy_DECREF(cpy_r_r48);
-    CPy_DECREF(cpy_r_r35);
+CPyL28: ;
+    cpy_r_r46 = CPyTagged_StealAsObject(cpy_r_r14);
+    PyObject *cpy_r_r47[1] = {cpy_r_r46};
+    cpy_r_r48 = (PyObject **)&cpy_r_r47;
+    cpy_r_r49 = PyObject_Vectorcall(cpy_r_r44, cpy_r_r48, 1, 0);
     if (unlikely(cpy_r_r49 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 83, CPyStatic_numeric___globals);
-        goto CPyL33;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 84, CPyStatic_numeric___globals);
+        goto CPyL84;
+    }
+    CPy_DECREF(cpy_r_r46);
+    cpy_r_r50 = PyNumber_Multiply(cpy_r_r49, cpy_r_r36);
+    CPy_DECREF(cpy_r_r49);
+    CPy_DECREF(cpy_r_r36);
+    if (unlikely(cpy_r_r50 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 84, CPyStatic_numeric___globals);
+        goto CPyL31;
     } else
-        goto CPyL88;
-CPyL32: ;
-    cpy_r_upper = cpy_r_r49;
-    goto CPyL41;
-CPyL33: ;
-    cpy_r_r50 = CPy_CatchError();
-    cpy_r_r30 = 0;
-    cpy_r_r51 = CPy_GetExcInfo();
-    cpy_r_r52 = cpy_r_r51.f0;
-    CPy_INCREF(cpy_r_r52);
-    cpy_r_r53 = cpy_r_r51.f1;
+        goto CPyL85;
+CPyL30: ;
+    cpy_r_upper = cpy_r_r50;
+    goto CPyL39;
+CPyL31: ;
+    cpy_r_r51 = CPy_CatchError();
+    cpy_r_r31 = 0;
+    cpy_r_r52 = CPy_GetExcInfo();
+    cpy_r_r53 = cpy_r_r52.f0;
     CPy_INCREF(cpy_r_r53);
-    cpy_r_r54 = cpy_r_r51.f2;
+    cpy_r_r54 = cpy_r_r52.f1;
     CPy_INCREF(cpy_r_r54);
+    cpy_r_r55 = cpy_r_r52.f2;
+    CPy_INCREF(cpy_r_r55);
+    CPy_DecRef(cpy_r_r52.f0);
+    CPy_DecRef(cpy_r_r52.f1);
+    CPy_DecRef(cpy_r_r52.f2);
+    PyObject *cpy_r_r56[4] = {cpy_r_r22, cpy_r_r53, cpy_r_r54, cpy_r_r55};
+    cpy_r_r57 = (PyObject **)&cpy_r_r56;
+    cpy_r_r58 = PyObject_Vectorcall(cpy_r_r25, cpy_r_r57, 4, 0);
+    if (unlikely(cpy_r_r58 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 81, CPyStatic_numeric___globals);
+        goto CPyL86;
+    }
+    CPy_DecRef(cpy_r_r53);
+    CPy_DecRef(cpy_r_r54);
+    CPy_DecRef(cpy_r_r55);
+    cpy_r_r59 = PyObject_IsTrue(cpy_r_r58);
+    CPy_DecRef(cpy_r_r58);
+    cpy_r_r60 = cpy_r_r59 >= 0;
+    if (unlikely(!cpy_r_r60)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 81, CPyStatic_numeric___globals);
+        goto CPyL37;
+    }
+    cpy_r_r61 = cpy_r_r59;
+    if (cpy_r_r61) goto CPyL36;
+    CPy_Reraise();
+    if (!0) {
+        goto CPyL37;
+    } else
+        goto CPyL87;
+CPyL35: ;
+    CPy_Unreachable();
+CPyL36: ;
+    CPy_RestoreExcInfo(cpy_r_r51);
     CPy_DecRef(cpy_r_r51.f0);
     CPy_DecRef(cpy_r_r51.f1);
     CPy_DecRef(cpy_r_r51.f2);
-    PyObject *cpy_r_r55[4] = {cpy_r_r21, cpy_r_r52, cpy_r_r53, cpy_r_r54};
-    cpy_r_r56 = (PyObject **)&cpy_r_r55;
-    cpy_r_r57 = PyObject_Vectorcall(cpy_r_r24, cpy_r_r56, 4, 0);
-    if (unlikely(cpy_r_r57 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 80, CPyStatic_numeric___globals);
-        goto CPyL89;
-    }
-    CPy_DecRef(cpy_r_r52);
-    CPy_DecRef(cpy_r_r53);
-    CPy_DecRef(cpy_r_r54);
-    cpy_r_r58 = PyObject_IsTrue(cpy_r_r57);
-    CPy_DecRef(cpy_r_r57);
-    cpy_r_r59 = cpy_r_r58 >= 0;
-    if (unlikely(!cpy_r_r59)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 80, CPyStatic_numeric___globals);
-        goto CPyL39;
-    }
-    cpy_r_r60 = cpy_r_r58;
-    if (cpy_r_r60) goto CPyL38;
-    CPy_Reraise();
-    if (!0) {
-        goto CPyL39;
-    } else
-        goto CPyL90;
+    goto CPyL39;
 CPyL37: ;
-    CPy_Unreachable();
+    CPy_RestoreExcInfo(cpy_r_r51);
+    CPy_DecRef(cpy_r_r51.f0);
+    CPy_DecRef(cpy_r_r51.f1);
+    CPy_DecRef(cpy_r_r51.f2);
+    cpy_r_r62 = CPy_KeepPropagating();
+    if (!cpy_r_r62) {
+        goto CPyL40;
+    } else
+        goto CPyL88;
 CPyL38: ;
-    CPy_RestoreExcInfo(cpy_r_r50);
-    CPy_DecRef(cpy_r_r50.f0);
-    CPy_DecRef(cpy_r_r50.f1);
-    CPy_DecRef(cpy_r_r50.f2);
-    goto CPyL41;
+    CPy_Unreachable();
 CPyL39: ;
-    CPy_RestoreExcInfo(cpy_r_r50);
-    CPy_DecRef(cpy_r_r50.f0);
-    CPy_DecRef(cpy_r_r50.f1);
-    CPy_DecRef(cpy_r_r50.f2);
-    cpy_r_r61 = CPy_KeepPropagating();
-    if (!cpy_r_r61) {
-        goto CPyL42;
+    tuple_T3OOO __tmp75 = { NULL, NULL, NULL };
+    cpy_r_r63 = __tmp75;
+    cpy_r_r64 = cpy_r_r63;
+    goto CPyL41;
+CPyL40: ;
+    cpy_r_r65 = CPy_CatchError();
+    cpy_r_r64 = cpy_r_r65;
+CPyL41: ;
+    if (!cpy_r_r31) goto CPyL89;
+    cpy_r_r66 = (PyObject *)&_Py_NoneStruct;
+    PyObject *cpy_r_r67[4] = {cpy_r_r22, cpy_r_r66, cpy_r_r66, cpy_r_r66};
+    cpy_r_r68 = (PyObject **)&cpy_r_r67;
+    cpy_r_r69 = PyObject_Vectorcall(cpy_r_r25, cpy_r_r68, 4, 0);
+    CPy_DECREF(cpy_r_r25);
+    if (unlikely(cpy_r_r69 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 81, CPyStatic_numeric___globals);
+        goto CPyL90;
     } else
         goto CPyL91;
-CPyL40: ;
-    CPy_Unreachable();
-CPyL41: ;
-    tuple_T3OOO __tmp75 = { NULL, NULL, NULL };
-    cpy_r_r62 = __tmp75;
-    cpy_r_r63 = cpy_r_r62;
-    goto CPyL43;
-CPyL42: ;
-    cpy_r_r64 = CPy_CatchError();
-    cpy_r_r63 = cpy_r_r64;
 CPyL43: ;
-    if (!cpy_r_r30) goto CPyL92;
-    cpy_r_r65 = (PyObject *)&_Py_NoneStruct;
-    PyObject *cpy_r_r66[4] = {cpy_r_r21, cpy_r_r65, cpy_r_r65, cpy_r_r65};
-    cpy_r_r67 = (PyObject **)&cpy_r_r66;
-    cpy_r_r68 = PyObject_Vectorcall(cpy_r_r24, cpy_r_r67, 4, 0);
-    CPy_DECREF(cpy_r_r24);
-    if (unlikely(cpy_r_r68 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 80, CPyStatic_numeric___globals);
-        goto CPyL93;
+    CPy_DECREF(cpy_r_r22);
+CPyL44: ;
+    if (cpy_r_r64.f0 == NULL) {
+        goto CPyL51;
     } else
-        goto CPyL94;
+        goto CPyL92;
 CPyL45: ;
-    CPy_DECREF(cpy_r_r21);
-CPyL46: ;
-    if (cpy_r_r63.f0 == NULL) {
-        goto CPyL53;
-    } else
-        goto CPyL95;
-CPyL47: ;
     CPy_Reraise();
     if (!0) {
-        goto CPyL49;
+        goto CPyL47;
     } else
-        goto CPyL96;
-CPyL48: ;
+        goto CPyL93;
+CPyL46: ;
     CPy_Unreachable();
+CPyL47: ;
+    if (cpy_r_r64.f0 == NULL) goto CPyL49;
+    CPy_RestoreExcInfo(cpy_r_r64);
+    CPy_XDECREF(cpy_r_r64.f0);
+    CPy_XDECREF(cpy_r_r64.f1);
+    CPy_XDECREF(cpy_r_r64.f2);
 CPyL49: ;
-    if (cpy_r_r63.f0 == NULL) goto CPyL51;
-    CPy_RestoreExcInfo(cpy_r_r63);
-    CPy_XDECREF(cpy_r_r63.f0);
-    CPy_XDECREF(cpy_r_r63.f1);
-    CPy_XDECREF(cpy_r_r63.f2);
+    cpy_r_r70 = CPy_KeepPropagating();
+    if (!cpy_r_r70) goto CPyL64;
+    CPy_Unreachable();
 CPyL51: ;
-    cpy_r_r69 = CPy_KeepPropagating();
-    if (!cpy_r_r69) goto CPyL66;
-    CPy_Unreachable();
-CPyL53: ;
     if (cpy_r_lower == NULL) {
-        goto CPyL97;
+        goto CPyL94;
     } else
-        goto CPyL56;
-CPyL54: ;
+        goto CPyL54;
+CPyL52: ;
     PyErr_SetString(PyExc_UnboundLocalError, "local variable \"lower\" referenced before assignment");
-    cpy_r_r70 = 0;
-    if (unlikely(!cpy_r_r70)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 85, CPyStatic_numeric___globals);
-        goto CPyL66;
-    }
-    CPy_Unreachable();
-CPyL56: ;
-    if (cpy_r_upper == NULL) {
-        goto CPyL98;
-    } else
-        goto CPyL59;
-CPyL57: ;
-    PyErr_SetString(PyExc_UnboundLocalError, "local variable \"upper\" referenced before assignment");
     cpy_r_r71 = 0;
     if (unlikely(!cpy_r_r71)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 85, CPyStatic_numeric___globals);
-        goto CPyL66;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 86, CPyStatic_numeric___globals);
+        goto CPyL64;
     }
     CPy_Unreachable();
-CPyL59: ;
-    cpy_r_r72.f0 = cpy_r_lower;
-    cpy_r_r72.f1 = cpy_r_upper;
-    cpy_r_r73 = PyTuple_New(2);
-    if (unlikely(cpy_r_r73 == NULL))
+CPyL54: ;
+    if (cpy_r_upper == NULL) {
+        goto CPyL95;
+    } else
+        goto CPyL57;
+CPyL55: ;
+    PyErr_SetString(PyExc_UnboundLocalError, "local variable \"upper\" referenced before assignment");
+    cpy_r_r72 = 0;
+    if (unlikely(!cpy_r_r72)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 86, CPyStatic_numeric___globals);
+        goto CPyL64;
+    }
+    CPy_Unreachable();
+CPyL57: ;
+    cpy_r_r73.f0 = cpy_r_lower;
+    cpy_r_r73.f1 = cpy_r_upper;
+    cpy_r_r74 = PyTuple_New(2);
+    if (unlikely(cpy_r_r74 == NULL))
         CPyError_OutOfMemory();
-    PyObject *__tmp76 = cpy_r_r72.f0;
-    PyTuple_SET_ITEM(cpy_r_r73, 0, __tmp76);
-    PyObject *__tmp77 = cpy_r_r72.f1;
-    PyTuple_SET_ITEM(cpy_r_r73, 1, __tmp77);
-    cpy_r_bounds = cpy_r_r73;
+    PyObject *__tmp76 = cpy_r_r73.f0;
+    PyTuple_SET_ITEM(cpy_r_r74, 0, __tmp76);
+    PyObject *__tmp77 = cpy_r_r73.f1;
+    PyTuple_SET_ITEM(cpy_r_r74, 1, __tmp77);
+    cpy_r_bounds = cpy_r_r74;
     PyObject *__tmp78;
     if (unlikely(!(PyTuple_Check(cpy_r_bounds) && PyTuple_GET_SIZE(cpy_r_bounds) == 2))) {
         __tmp78 = NULL;
@@ -12528,64 +12516,64 @@ CPyL59: ;
     __tmp78 = cpy_r_bounds;
 __LL79: ;
     if (unlikely(__tmp78 == NULL)) {
-        CPy_TypeError("tuple[object, object]", cpy_r_bounds); cpy_r_r74 = (tuple_T2OO) { NULL, NULL };
+        CPy_TypeError("tuple[object, object]", cpy_r_bounds); cpy_r_r75 = (tuple_T2OO) { NULL, NULL };
     } else {
         PyObject *__tmp80 = PyTuple_GET_ITEM(cpy_r_bounds, 0);
         CPy_INCREF(__tmp80);
         PyObject *__tmp81;
         __tmp81 = __tmp80;
-        cpy_r_r74.f0 = __tmp81;
+        cpy_r_r75.f0 = __tmp81;
         PyObject *__tmp82 = PyTuple_GET_ITEM(cpy_r_bounds, 1);
         CPy_INCREF(__tmp82);
         PyObject *__tmp83;
         __tmp83 = __tmp82;
-        cpy_r_r74.f1 = __tmp83;
+        cpy_r_r75.f1 = __tmp83;
     }
-    if (unlikely(cpy_r_r74.f0 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 86, CPyStatic_numeric___globals);
-        goto CPyL99;
+    if (unlikely(cpy_r_r75.f0 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 87, CPyStatic_numeric___globals);
+        goto CPyL96;
     }
-    cpy_r_r75 = CPyStatic_numeric____signed_fixed_bounds_cache;
-    if (unlikely(cpy_r_r75 == NULL)) {
-        goto CPyL100;
+    cpy_r_r76 = CPyStatic_numeric____signed_fixed_bounds_cache;
+    if (unlikely(cpy_r_r76 == NULL)) {
+        goto CPyL97;
     } else
-        goto CPyL63;
-CPyL61: ;
+        goto CPyL61;
+CPyL59: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"_signed_fixed_bounds_cache\" was not set");
-    cpy_r_r76 = 0;
-    if (unlikely(!cpy_r_r76)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 86, CPyStatic_numeric___globals);
-        goto CPyL66;
+    cpy_r_r77 = 0;
+    if (unlikely(!cpy_r_r77)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 87, CPyStatic_numeric___globals);
+        goto CPyL64;
     }
     CPy_Unreachable();
-CPyL63: ;
+CPyL61: ;
     CPyTagged_INCREF(cpy_r_num_bits);
     CPyTagged_INCREF(cpy_r_frac_places);
-    cpy_r_r77.f0 = cpy_r_num_bits;
-    cpy_r_r77.f1 = cpy_r_frac_places;
-    cpy_r_r78 = PyTuple_New(2);
-    if (unlikely(cpy_r_r78 == NULL))
-        CPyError_OutOfMemory();
-    PyObject *__tmp84 = CPyTagged_StealAsObject(cpy_r_r77.f0);
-    PyTuple_SET_ITEM(cpy_r_r78, 0, __tmp84);
-    PyObject *__tmp85 = CPyTagged_StealAsObject(cpy_r_r77.f1);
-    PyTuple_SET_ITEM(cpy_r_r78, 1, __tmp85);
+    cpy_r_r78.f0 = cpy_r_num_bits;
+    cpy_r_r78.f1 = cpy_r_frac_places;
     cpy_r_r79 = PyTuple_New(2);
     if (unlikely(cpy_r_r79 == NULL))
         CPyError_OutOfMemory();
-    PyObject *__tmp86 = cpy_r_r74.f0;
-    PyTuple_SET_ITEM(cpy_r_r79, 0, __tmp86);
-    PyObject *__tmp87 = cpy_r_r74.f1;
-    PyTuple_SET_ITEM(cpy_r_r79, 1, __tmp87);
-    cpy_r_r80 = CPyDict_SetItem(cpy_r_r75, cpy_r_r78, cpy_r_r79);
-    CPy_DECREF(cpy_r_r78);
+    PyObject *__tmp84 = CPyTagged_StealAsObject(cpy_r_r78.f0);
+    PyTuple_SET_ITEM(cpy_r_r79, 0, __tmp84);
+    PyObject *__tmp85 = CPyTagged_StealAsObject(cpy_r_r78.f1);
+    PyTuple_SET_ITEM(cpy_r_r79, 1, __tmp85);
+    cpy_r_r80 = PyTuple_New(2);
+    if (unlikely(cpy_r_r80 == NULL))
+        CPyError_OutOfMemory();
+    PyObject *__tmp86 = cpy_r_r75.f0;
+    PyTuple_SET_ITEM(cpy_r_r80, 0, __tmp86);
+    PyObject *__tmp87 = cpy_r_r75.f1;
+    PyTuple_SET_ITEM(cpy_r_r80, 1, __tmp87);
+    cpy_r_r81 = CPyDict_SetItem(cpy_r_r76, cpy_r_r79, cpy_r_r80);
     CPy_DECREF(cpy_r_r79);
-    cpy_r_r81 = cpy_r_r80 >= 0;
-    if (unlikely(!cpy_r_r81)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 86, CPyStatic_numeric___globals);
-        goto CPyL99;
+    CPy_DECREF(cpy_r_r80);
+    cpy_r_r82 = cpy_r_r81 >= 0;
+    if (unlikely(!cpy_r_r82)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 87, CPyStatic_numeric___globals);
+        goto CPyL96;
     }
-CPyL64: ;
+CPyL62: ;
     PyObject *__tmp88;
     if (unlikely(!(PyTuple_Check(cpy_r_bounds) && PyTuple_GET_SIZE(cpy_r_bounds) == 2))) {
         __tmp88 = NULL;
@@ -12598,190 +12586,184 @@ CPyL64: ;
     __tmp88 = cpy_r_bounds;
 __LL89: ;
     if (unlikely(__tmp88 == NULL)) {
-        CPy_TypeError("tuple[object, object]", cpy_r_bounds); cpy_r_r82 = (tuple_T2OO) { NULL, NULL };
+        CPy_TypeError("tuple[object, object]", cpy_r_bounds); cpy_r_r83 = (tuple_T2OO) { NULL, NULL };
     } else {
         PyObject *__tmp90 = PyTuple_GET_ITEM(cpy_r_bounds, 0);
         CPy_INCREF(__tmp90);
         PyObject *__tmp91;
         __tmp91 = __tmp90;
-        cpy_r_r82.f0 = __tmp91;
+        cpy_r_r83.f0 = __tmp91;
         PyObject *__tmp92 = PyTuple_GET_ITEM(cpy_r_bounds, 1);
         CPy_INCREF(__tmp92);
         PyObject *__tmp93;
         __tmp93 = __tmp92;
-        cpy_r_r82.f1 = __tmp93;
+        cpy_r_r83.f1 = __tmp93;
     }
     CPy_DECREF(cpy_r_bounds);
-    if (unlikely(cpy_r_r82.f0 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 88, CPyStatic_numeric___globals);
-        goto CPyL66;
+    if (unlikely(cpy_r_r83.f0 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 89, CPyStatic_numeric___globals);
+        goto CPyL64;
     }
-    return cpy_r_r82;
-CPyL66: ;
-    tuple_T2OO __tmp94 = { NULL, NULL };
-    cpy_r_r83 = __tmp94;
     return cpy_r_r83;
-CPyL67: ;
+CPyL64: ;
+    tuple_T2OO __tmp94 = { NULL, NULL };
+    cpy_r_r84 = __tmp94;
+    return cpy_r_r84;
+CPyL65: ;
     CPy_XDecRef(cpy_r_lower);
     CPy_XDecRef(cpy_r_upper);
     goto CPyL1;
-CPyL68: ;
+CPyL66: ;
     CPy_XDecRef(cpy_r_lower);
     CPy_XDecRef(cpy_r_upper);
-    goto CPyL66;
-CPyL69: ;
+    goto CPyL64;
+CPyL67: ;
     CPy_DECREF(cpy_r_bounds);
     goto CPyL6;
-CPyL70: ;
+CPyL68: ;
     CPy_XDECREF(cpy_r_lower);
     CPy_XDECREF(cpy_r_upper);
+    goto CPyL62;
+CPyL69: ;
+    CPy_XDecRef(cpy_r_lower);
+    CPy_XDecRef(cpy_r_upper);
+    CPyTagged_DecRef(cpy_r_r13);
+    CPyTagged_DecRef(cpy_r_r14);
+    goto CPyL8;
+CPyL70: ;
+    CPy_XDecRef(cpy_r_lower);
+    CPy_XDecRef(cpy_r_upper);
+    CPyTagged_DecRef(cpy_r_r13);
+    CPyTagged_DecRef(cpy_r_r14);
     goto CPyL64;
 CPyL71: ;
     CPy_XDecRef(cpy_r_lower);
     CPy_XDecRef(cpy_r_upper);
     CPyTagged_DecRef(cpy_r_r13);
     CPyTagged_DecRef(cpy_r_r14);
-    goto CPyL8;
+    CPy_DecRef(cpy_r_r22);
+    CPy_DecRef(cpy_r_r23);
+    goto CPyL64;
 CPyL72: ;
     CPy_XDecRef(cpy_r_lower);
     CPy_XDecRef(cpy_r_upper);
     CPyTagged_DecRef(cpy_r_r13);
     CPyTagged_DecRef(cpy_r_r14);
-    goto CPyL11;
-CPyL73: ;
-    CPy_XDecRef(cpy_r_lower);
-    CPy_XDecRef(cpy_r_upper);
-    CPyTagged_DecRef(cpy_r_r13);
-    CPyTagged_DecRef(cpy_r_r14);
-    goto CPyL66;
-CPyL74: ;
-    CPy_XDecRef(cpy_r_lower);
-    CPy_XDecRef(cpy_r_upper);
-    CPyTagged_DecRef(cpy_r_r13);
-    CPyTagged_DecRef(cpy_r_r14);
-    CPy_DecRef(cpy_r_r21);
     CPy_DecRef(cpy_r_r22);
-    goto CPyL66;
+    CPy_DecRef(cpy_r_r25);
+    goto CPyL64;
+CPyL73: ;
+    CPy_DECREF(cpy_r_r30);
+    goto CPyL15;
+CPyL74: ;
+    CPyTagged_DecRef(cpy_r_r13);
+    CPyTagged_DecRef(cpy_r_r14);
+    goto CPyL17;
 CPyL75: ;
     CPy_XDecRef(cpy_r_lower);
     CPy_XDecRef(cpy_r_upper);
+    CPy_DecRef(cpy_r_r22);
+    CPy_DecRef(cpy_r_r25);
+    goto CPyL18;
+CPyL76: ;
     CPyTagged_DecRef(cpy_r_r13);
     CPyTagged_DecRef(cpy_r_r14);
-    CPy_DecRef(cpy_r_r21);
-    CPy_DecRef(cpy_r_r24);
-    goto CPyL66;
-CPyL76: ;
-    CPy_DECREF(cpy_r_r29);
-    goto CPyL17;
+    goto CPyL31;
 CPyL77: ;
     CPyTagged_DecRef(cpy_r_r13);
     CPyTagged_DecRef(cpy_r_r14);
-    goto CPyL19;
+    CPy_DecRef(cpy_r_r36);
+    goto CPyL21;
 CPyL78: ;
     CPy_XDecRef(cpy_r_lower);
     CPy_XDecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r21);
-    CPy_DecRef(cpy_r_r24);
-    goto CPyL20;
+    CPy_DecRef(cpy_r_r22);
+    CPy_DecRef(cpy_r_r25);
+    goto CPyL22;
 CPyL79: ;
-    CPyTagged_DecRef(cpy_r_r13);
     CPyTagged_DecRef(cpy_r_r14);
-    goto CPyL33;
+    CPy_DecRef(cpy_r_r36);
+    CPy_DecRef(cpy_r_r39);
+    goto CPyL31;
 CPyL80: ;
-    CPyTagged_DecRef(cpy_r_r13);
     CPyTagged_DecRef(cpy_r_r14);
-    CPy_DecRef(cpy_r_r35);
-    goto CPyL23;
+    CPy_DecRef(cpy_r_r36);
+    goto CPyL31;
 CPyL81: ;
-    CPy_XDecRef(cpy_r_lower);
-    CPy_XDecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r21);
-    CPy_DecRef(cpy_r_r24);
-    goto CPyL24;
+    CPy_XDECREF(cpy_r_lower);
+    goto CPyL25;
 CPyL82: ;
     CPyTagged_DecRef(cpy_r_r14);
-    CPy_DecRef(cpy_r_r35);
-    CPy_DecRef(cpy_r_r38);
-    goto CPyL33;
+    CPy_DecRef(cpy_r_r36);
+    goto CPyL26;
 CPyL83: ;
-    CPyTagged_DecRef(cpy_r_r14);
-    CPy_DecRef(cpy_r_r35);
-    goto CPyL33;
-CPyL84: ;
-    CPy_XDECREF(cpy_r_lower);
-    goto CPyL27;
-CPyL85: ;
-    CPyTagged_DecRef(cpy_r_r14);
-    CPy_DecRef(cpy_r_r35);
-    goto CPyL28;
-CPyL86: ;
     CPy_DecRef(cpy_r_lower);
     CPy_XDecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r21);
-    CPy_DecRef(cpy_r_r24);
-    goto CPyL29;
-CPyL87: ;
-    CPy_DecRef(cpy_r_r35);
-    CPy_DecRef(cpy_r_r45);
-    goto CPyL33;
-CPyL88: ;
+    CPy_DecRef(cpy_r_r22);
+    CPy_DecRef(cpy_r_r25);
+    goto CPyL27;
+CPyL84: ;
+    CPy_DecRef(cpy_r_r36);
+    CPy_DecRef(cpy_r_r46);
+    goto CPyL31;
+CPyL85: ;
     CPy_XDECREF(cpy_r_upper);
-    goto CPyL32;
-CPyL89: ;
-    CPy_DecRef(cpy_r_r52);
+    goto CPyL30;
+CPyL86: ;
     CPy_DecRef(cpy_r_r53);
     CPy_DecRef(cpy_r_r54);
-    goto CPyL39;
+    CPy_DecRef(cpy_r_r55);
+    goto CPyL37;
+CPyL87: ;
+    CPy_XDecRef(cpy_r_lower);
+    CPy_XDecRef(cpy_r_upper);
+    CPy_DecRef(cpy_r_r22);
+    CPy_DecRef(cpy_r_r25);
+    CPy_DecRef(cpy_r_r51.f0);
+    CPy_DecRef(cpy_r_r51.f1);
+    CPy_DecRef(cpy_r_r51.f2);
+    goto CPyL35;
+CPyL88: ;
+    CPy_XDecRef(cpy_r_lower);
+    CPy_XDecRef(cpy_r_upper);
+    CPy_DecRef(cpy_r_r22);
+    CPy_DecRef(cpy_r_r25);
+    goto CPyL38;
+CPyL89: ;
+    CPy_DECREF(cpy_r_r22);
+    CPy_DECREF(cpy_r_r25);
+    goto CPyL44;
 CPyL90: ;
     CPy_XDecRef(cpy_r_lower);
     CPy_XDecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r21);
-    CPy_DecRef(cpy_r_r24);
-    CPy_DecRef(cpy_r_r50.f0);
-    CPy_DecRef(cpy_r_r50.f1);
-    CPy_DecRef(cpy_r_r50.f2);
-    goto CPyL37;
+    CPy_DecRef(cpy_r_r22);
+    goto CPyL47;
 CPyL91: ;
-    CPy_XDecRef(cpy_r_lower);
-    CPy_XDecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r21);
-    CPy_DecRef(cpy_r_r24);
-    goto CPyL40;
+    CPy_DECREF(cpy_r_r69);
+    goto CPyL43;
 CPyL92: ;
-    CPy_DECREF(cpy_r_r21);
-    CPy_DECREF(cpy_r_r24);
-    goto CPyL46;
-CPyL93: ;
-    CPy_XDecRef(cpy_r_lower);
-    CPy_XDecRef(cpy_r_upper);
-    CPy_DecRef(cpy_r_r21);
-    goto CPyL49;
-CPyL94: ;
-    CPy_DECREF(cpy_r_r68);
+    CPy_XDECREF(cpy_r_lower);
+    CPy_XDECREF(cpy_r_upper);
     goto CPyL45;
+CPyL93: ;
+    CPy_XDECREF(cpy_r_r64.f0);
+    CPy_XDECREF(cpy_r_r64.f1);
+    CPy_XDECREF(cpy_r_r64.f2);
+    goto CPyL46;
+CPyL94: ;
+    CPy_XDECREF(cpy_r_upper);
+    goto CPyL52;
 CPyL95: ;
     CPy_XDECREF(cpy_r_lower);
-    CPy_XDECREF(cpy_r_upper);
-    goto CPyL47;
+    goto CPyL55;
 CPyL96: ;
-    CPy_XDECREF(cpy_r_r63.f0);
-    CPy_XDECREF(cpy_r_r63.f1);
-    CPy_XDECREF(cpy_r_r63.f2);
-    goto CPyL48;
+    CPy_DecRef(cpy_r_bounds);
+    goto CPyL64;
 CPyL97: ;
-    CPy_XDECREF(cpy_r_upper);
-    goto CPyL54;
-CPyL98: ;
-    CPy_XDECREF(cpy_r_lower);
-    goto CPyL57;
-CPyL99: ;
     CPy_DecRef(cpy_r_bounds);
-    goto CPyL66;
-CPyL100: ;
-    CPy_DecRef(cpy_r_bounds);
-    CPy_DecRef(cpy_r_r74.f0);
-    CPy_DecRef(cpy_r_r74.f1);
-    goto CPyL61;
+    CPy_DecRef(cpy_r_r75.f0);
+    CPy_DecRef(cpy_r_r75.f1);
+    goto CPyL59;
 }
 
 PyObject *CPyPy_numeric___compute_signed_fixed_bounds(PyObject *self, PyObject *const *args, size_t nargs, PyObject *kwnames) {
@@ -12817,7 +12799,7 @@ PyObject *CPyPy_numeric___compute_signed_fixed_bounds(PyObject *self, PyObject *
     PyTuple_SET_ITEM(retbox, 1, __tmp96);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 72, CPyStatic_numeric___globals);
+    CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "compute_signed_fixed_bounds", 73, CPyStatic_numeric___globals);
     return NULL;
 }
 
@@ -12864,302 +12846,294 @@ PyObject *CPyDef_numeric___f_scale_places_obj_____call__(PyObject *cpy_r___mypyc
     PyObject *cpy_r_r1;
     char cpy_r_r2;
     PyObject *cpy_r_r3;
-    char cpy_r_r4;
-    PyObject **cpy_r_r6;
-    PyObject *cpy_r_r7;
+    PyObject *cpy_r_r4;
+    PyObject *cpy_r_r5;
+    PyObject **cpy_r_r7;
     PyObject *cpy_r_r8;
     PyObject *cpy_r_r9;
     PyObject *cpy_r_r10;
     PyObject *cpy_r_r11;
     PyObject *cpy_r_r12;
-    PyObject **cpy_r_r14;
-    PyObject *cpy_r_r15;
-    char cpy_r_r16;
-    PyObject *cpy_r_r17;
+    PyObject *cpy_r_r13;
+    PyObject **cpy_r_r15;
+    PyObject *cpy_r_r16;
+    char cpy_r_r17;
     PyObject *cpy_r_r18;
     PyObject *cpy_r_r19;
-    tuple_T3OOO cpy_r_r20;
+    PyObject *cpy_r_r20;
     tuple_T3OOO cpy_r_r21;
-    PyObject *cpy_r_r22;
+    tuple_T3OOO cpy_r_r22;
     PyObject *cpy_r_r23;
     PyObject *cpy_r_r24;
-    PyObject **cpy_r_r26;
-    PyObject *cpy_r_r27;
-    int32_t cpy_r_r28;
-    char cpy_r_r29;
+    PyObject *cpy_r_r25;
+    PyObject **cpy_r_r27;
+    PyObject *cpy_r_r28;
+    int32_t cpy_r_r29;
     char cpy_r_r30;
     char cpy_r_r31;
-    PyObject *cpy_r_r32;
-    tuple_T3OOO cpy_r_r33;
+    char cpy_r_r32;
+    PyObject *cpy_r_r33;
     tuple_T3OOO cpy_r_r34;
-    PyObject *cpy_r_r35;
-    tuple_T3OOO cpy_r_r36;
-    PyObject *cpy_r_r37;
-    PyObject **cpy_r_r39;
-    PyObject *cpy_r_r40;
-    char cpy_r_r41;
-    PyObject *cpy_r_r42;
+    tuple_T3OOO cpy_r_r35;
+    PyObject *cpy_r_r36;
+    tuple_T3OOO cpy_r_r37;
+    PyObject *cpy_r_r38;
+    PyObject **cpy_r_r40;
+    PyObject *cpy_r_r41;
+    char cpy_r_r42;
     PyObject *cpy_r_r43;
+    PyObject *cpy_r_r44;
     cpy_r_r0 = ((faster_eth_abi___utils___numeric___f_scale_places_objObject *)cpy_r___mypyc_self__)->___mypyc_env__;
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AttributeError("faster_eth_abi/utils/numeric.py", "f", "f_scale_places_obj", "__mypyc_env__", 105, CPyStatic_numeric___globals);
-        goto CPyL39;
+        CPy_AttributeError("faster_eth_abi/utils/numeric.py", "f", "f_scale_places_obj", "__mypyc_env__", 106, CPyStatic_numeric___globals);
+        goto CPyL37;
     }
     CPy_INCREF_NO_IMM(cpy_r_r0);
 CPyL1: ;
     cpy_r_r1 = CPyStatic_numeric___abi_decimal_context;
     if (unlikely(cpy_r_r1 == NULL)) {
-        goto CPyL40;
+        goto CPyL38;
     } else
         goto CPyL4;
 CPyL2: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"abi_decimal_context\" was not set");
     cpy_r_r2 = 0;
     if (unlikely(!cpy_r_r2)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 106, CPyStatic_numeric___globals);
-        goto CPyL39;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 107, CPyStatic_numeric___globals);
+        goto CPyL37;
     }
     CPy_Unreachable();
 CPyL4: ;
-    cpy_r_r3 = CPyStatic_numeric___decimal_localcontext;
-    if (unlikely(cpy_r_r3 == NULL)) {
-        goto CPyL41;
-    } else
-        goto CPyL7;
-CPyL5: ;
-    PyErr_SetString(PyExc_NameError, "value for final name \"decimal_localcontext\" was not set");
-    cpy_r_r4 = 0;
-    if (unlikely(!cpy_r_r4)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 106, CPyStatic_numeric___globals);
+    cpy_r_r3 = CPyModule_decimal;
+    cpy_r_r4 = CPyStatics[187]; /* 'localcontext' */
+    cpy_r_r5 = CPyObject_GetAttr(cpy_r_r3, cpy_r_r4);
+    if (unlikely(cpy_r_r5 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 107, CPyStatic_numeric___globals);
         goto CPyL39;
     }
-    CPy_Unreachable();
-CPyL7: ;
-    PyObject *cpy_r_r5[1] = {cpy_r_r1};
-    cpy_r_r6 = (PyObject **)&cpy_r_r5;
-    cpy_r_r7 = PyObject_Vectorcall(cpy_r_r3, cpy_r_r6, 1, 0);
-    if (unlikely(cpy_r_r7 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 106, CPyStatic_numeric___globals);
-        goto CPyL42;
+    PyObject *cpy_r_r6[1] = {cpy_r_r1};
+    cpy_r_r7 = (PyObject **)&cpy_r_r6;
+    cpy_r_r8 = PyObject_Vectorcall(cpy_r_r5, cpy_r_r7, 1, 0);
+    CPy_DECREF(cpy_r_r5);
+    if (unlikely(cpy_r_r8 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 107, CPyStatic_numeric___globals);
+        goto CPyL39;
     }
-    cpy_r_r8 = CPy_TYPE(cpy_r_r7);
-    cpy_r_r9 = CPyStatics[187]; /* '__exit__' */
-    cpy_r_r10 = CPyObject_GetAttr(cpy_r_r8, cpy_r_r9);
-    if (unlikely(cpy_r_r10 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 106, CPyStatic_numeric___globals);
-        goto CPyL43;
+    cpy_r_r9 = CPy_TYPE(cpy_r_r8);
+    cpy_r_r10 = CPyStatics[188]; /* '__exit__' */
+    cpy_r_r11 = CPyObject_GetAttr(cpy_r_r9, cpy_r_r10);
+    if (unlikely(cpy_r_r11 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 107, CPyStatic_numeric___globals);
+        goto CPyL40;
     }
-    cpy_r_r11 = CPyStatics[188]; /* '__enter__' */
-    cpy_r_r12 = CPyObject_GetAttr(cpy_r_r8, cpy_r_r11);
-    CPy_DECREF(cpy_r_r8);
-    if (unlikely(cpy_r_r12 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 106, CPyStatic_numeric___globals);
-        goto CPyL44;
+    cpy_r_r12 = CPyStatics[189]; /* '__enter__' */
+    cpy_r_r13 = CPyObject_GetAttr(cpy_r_r9, cpy_r_r12);
+    CPy_DECREF(cpy_r_r9);
+    if (unlikely(cpy_r_r13 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 107, CPyStatic_numeric___globals);
+        goto CPyL41;
     }
-    PyObject *cpy_r_r13[1] = {cpy_r_r7};
-    cpy_r_r14 = (PyObject **)&cpy_r_r13;
-    cpy_r_r15 = PyObject_Vectorcall(cpy_r_r12, cpy_r_r14, 1, 0);
-    CPy_DECREF(cpy_r_r12);
-    if (unlikely(cpy_r_r15 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 106, CPyStatic_numeric___globals);
-        goto CPyL44;
+    PyObject *cpy_r_r14[1] = {cpy_r_r8};
+    cpy_r_r15 = (PyObject **)&cpy_r_r14;
+    cpy_r_r16 = PyObject_Vectorcall(cpy_r_r13, cpy_r_r15, 1, 0);
+    CPy_DECREF(cpy_r_r13);
+    if (unlikely(cpy_r_r16 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 107, CPyStatic_numeric___globals);
+        goto CPyL41;
     } else
-        goto CPyL45;
-CPyL11: ;
-    cpy_r_r16 = 1;
-    cpy_r_r17 = ((faster_eth_abi___utils___numeric___scale_places_envObject *)cpy_r_r0)->_scaling_factor;
-    if (unlikely(cpy_r_r17 == NULL)) {
+        goto CPyL42;
+CPyL9: ;
+    cpy_r_r17 = 1;
+    cpy_r_r18 = ((faster_eth_abi___utils___numeric___scale_places_envObject *)cpy_r_r0)->_scaling_factor;
+    if (unlikely(cpy_r_r18 == NULL)) {
         PyErr_SetString(PyExc_AttributeError, "attribute 'scaling_factor' of 'scale_places_env' undefined");
     } else {
-        CPy_INCREF(cpy_r_r17);
+        CPy_INCREF(cpy_r_r18);
     }
     CPy_DECREF_NO_IMM(cpy_r_r0);
-    if (unlikely(cpy_r_r17 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 107, CPyStatic_numeric___globals);
-        goto CPyL15;
-    }
-CPyL13: ;
-    cpy_r_r18 = PyNumber_Multiply(cpy_r_x, cpy_r_r17);
-    CPy_DECREF(cpy_r_r17);
     if (unlikely(cpy_r_r18 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 107, CPyStatic_numeric___globals);
-        goto CPyL15;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 108, CPyStatic_numeric___globals);
+        goto CPyL13;
     }
-    cpy_r_r19 = cpy_r_r18;
-    goto CPyL24;
-CPyL15: ;
-    cpy_r_r20 = CPy_CatchError();
-    cpy_r_r16 = 0;
-    cpy_r_r21 = CPy_GetExcInfo();
-    cpy_r_r22 = cpy_r_r21.f0;
-    CPy_INCREF(cpy_r_r22);
-    cpy_r_r23 = cpy_r_r21.f1;
+CPyL11: ;
+    cpy_r_r19 = PyNumber_Multiply(cpy_r_x, cpy_r_r18);
+    CPy_DECREF(cpy_r_r18);
+    if (unlikely(cpy_r_r19 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 108, CPyStatic_numeric___globals);
+        goto CPyL13;
+    }
+    cpy_r_r20 = cpy_r_r19;
+    goto CPyL22;
+CPyL13: ;
+    cpy_r_r21 = CPy_CatchError();
+    cpy_r_r17 = 0;
+    cpy_r_r22 = CPy_GetExcInfo();
+    cpy_r_r23 = cpy_r_r22.f0;
     CPy_INCREF(cpy_r_r23);
-    cpy_r_r24 = cpy_r_r21.f2;
+    cpy_r_r24 = cpy_r_r22.f1;
     CPy_INCREF(cpy_r_r24);
+    cpy_r_r25 = cpy_r_r22.f2;
+    CPy_INCREF(cpy_r_r25);
+    CPy_DecRef(cpy_r_r22.f0);
+    CPy_DecRef(cpy_r_r22.f1);
+    CPy_DecRef(cpy_r_r22.f2);
+    PyObject *cpy_r_r26[4] = {cpy_r_r8, cpy_r_r23, cpy_r_r24, cpy_r_r25};
+    cpy_r_r27 = (PyObject **)&cpy_r_r26;
+    cpy_r_r28 = PyObject_Vectorcall(cpy_r_r11, cpy_r_r27, 4, 0);
+    if (unlikely(cpy_r_r28 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 107, CPyStatic_numeric___globals);
+        goto CPyL43;
+    }
+    CPy_DecRef(cpy_r_r23);
+    CPy_DecRef(cpy_r_r24);
+    CPy_DecRef(cpy_r_r25);
+    cpy_r_r29 = PyObject_IsTrue(cpy_r_r28);
+    CPy_DecRef(cpy_r_r28);
+    cpy_r_r30 = cpy_r_r29 >= 0;
+    if (unlikely(!cpy_r_r30)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 107, CPyStatic_numeric___globals);
+        goto CPyL19;
+    }
+    cpy_r_r31 = cpy_r_r29;
+    if (cpy_r_r31) goto CPyL18;
+    CPy_Reraise();
+    if (!0) {
+        goto CPyL19;
+    } else
+        goto CPyL44;
+CPyL17: ;
+    CPy_Unreachable();
+CPyL18: ;
+    CPy_RestoreExcInfo(cpy_r_r21);
     CPy_DecRef(cpy_r_r21.f0);
     CPy_DecRef(cpy_r_r21.f1);
     CPy_DecRef(cpy_r_r21.f2);
-    PyObject *cpy_r_r25[4] = {cpy_r_r7, cpy_r_r22, cpy_r_r23, cpy_r_r24};
-    cpy_r_r26 = (PyObject **)&cpy_r_r25;
-    cpy_r_r27 = PyObject_Vectorcall(cpy_r_r10, cpy_r_r26, 4, 0);
-    if (unlikely(cpy_r_r27 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 106, CPyStatic_numeric___globals);
-        goto CPyL46;
-    }
-    CPy_DecRef(cpy_r_r22);
-    CPy_DecRef(cpy_r_r23);
-    CPy_DecRef(cpy_r_r24);
-    cpy_r_r28 = PyObject_IsTrue(cpy_r_r27);
-    CPy_DecRef(cpy_r_r27);
-    cpy_r_r29 = cpy_r_r28 >= 0;
-    if (unlikely(!cpy_r_r29)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 106, CPyStatic_numeric___globals);
-        goto CPyL21;
-    }
-    cpy_r_r30 = cpy_r_r28;
-    if (cpy_r_r30) goto CPyL20;
-    CPy_Reraise();
-    if (!0) {
-        goto CPyL21;
-    } else
-        goto CPyL47;
+    goto CPyL21;
 CPyL19: ;
-    CPy_Unreachable();
+    CPy_RestoreExcInfo(cpy_r_r21);
+    CPy_DecRef(cpy_r_r21.f0);
+    CPy_DecRef(cpy_r_r21.f1);
+    CPy_DecRef(cpy_r_r21.f2);
+    cpy_r_r32 = CPy_KeepPropagating();
+    if (!cpy_r_r32) {
+        goto CPyL23;
+    } else
+        goto CPyL45;
 CPyL20: ;
-    CPy_RestoreExcInfo(cpy_r_r20);
-    CPy_DecRef(cpy_r_r20.f0);
-    CPy_DecRef(cpy_r_r20.f1);
-    CPy_DecRef(cpy_r_r20.f2);
-    goto CPyL23;
+    CPy_Unreachable();
 CPyL21: ;
-    CPy_RestoreExcInfo(cpy_r_r20);
-    CPy_DecRef(cpy_r_r20.f0);
-    CPy_DecRef(cpy_r_r20.f1);
-    CPy_DecRef(cpy_r_r20.f2);
-    cpy_r_r31 = CPy_KeepPropagating();
-    if (!cpy_r_r31) {
-        goto CPyL25;
+    cpy_r_r33 = NULL;
+    cpy_r_r20 = cpy_r_r33;
+CPyL22: ;
+    tuple_T3OOO __tmp97 = { NULL, NULL, NULL };
+    cpy_r_r34 = __tmp97;
+    cpy_r_r35 = cpy_r_r34;
+    goto CPyL24;
+CPyL23: ;
+    cpy_r_r36 = NULL;
+    cpy_r_r20 = cpy_r_r36;
+    cpy_r_r37 = CPy_CatchError();
+    cpy_r_r35 = cpy_r_r37;
+CPyL24: ;
+    if (!cpy_r_r17) goto CPyL46;
+    cpy_r_r38 = (PyObject *)&_Py_NoneStruct;
+    PyObject *cpy_r_r39[4] = {cpy_r_r8, cpy_r_r38, cpy_r_r38, cpy_r_r38};
+    cpy_r_r40 = (PyObject **)&cpy_r_r39;
+    cpy_r_r41 = PyObject_Vectorcall(cpy_r_r11, cpy_r_r40, 4, 0);
+    CPy_DECREF(cpy_r_r11);
+    if (unlikely(cpy_r_r41 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 107, CPyStatic_numeric___globals);
+        goto CPyL47;
     } else
         goto CPyL48;
-CPyL22: ;
-    CPy_Unreachable();
-CPyL23: ;
-    cpy_r_r32 = NULL;
-    cpy_r_r19 = cpy_r_r32;
-CPyL24: ;
-    tuple_T3OOO __tmp97 = { NULL, NULL, NULL };
-    cpy_r_r33 = __tmp97;
-    cpy_r_r34 = cpy_r_r33;
-    goto CPyL26;
-CPyL25: ;
-    cpy_r_r35 = NULL;
-    cpy_r_r19 = cpy_r_r35;
-    cpy_r_r36 = CPy_CatchError();
-    cpy_r_r34 = cpy_r_r36;
 CPyL26: ;
-    if (!cpy_r_r16) goto CPyL49;
-    cpy_r_r37 = (PyObject *)&_Py_NoneStruct;
-    PyObject *cpy_r_r38[4] = {cpy_r_r7, cpy_r_r37, cpy_r_r37, cpy_r_r37};
-    cpy_r_r39 = (PyObject **)&cpy_r_r38;
-    cpy_r_r40 = PyObject_Vectorcall(cpy_r_r10, cpy_r_r39, 4, 0);
-    CPy_DECREF(cpy_r_r10);
-    if (unlikely(cpy_r_r40 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 106, CPyStatic_numeric___globals);
-        goto CPyL50;
+    CPy_DECREF(cpy_r_r8);
+CPyL27: ;
+    if (cpy_r_r35.f0 == NULL) {
+        goto CPyL30;
     } else
-        goto CPyL51;
+        goto CPyL49;
 CPyL28: ;
-    CPy_DECREF(cpy_r_r7);
-CPyL29: ;
-    if (cpy_r_r34.f0 == NULL) {
-        goto CPyL32;
-    } else
-        goto CPyL52;
-CPyL30: ;
     CPy_Reraise();
     if (!0) {
-        goto CPyL34;
+        goto CPyL32;
     } else
-        goto CPyL53;
-CPyL31: ;
+        goto CPyL50;
+CPyL29: ;
     CPy_Unreachable();
+CPyL30: ;
+    if (cpy_r_r20 == NULL) goto CPyL36;
+    return cpy_r_r20;
 CPyL32: ;
-    if (cpy_r_r19 == NULL) goto CPyL38;
-    return cpy_r_r19;
+    if (cpy_r_r35.f0 == NULL) goto CPyL34;
+    CPy_RestoreExcInfo(cpy_r_r35);
+    CPy_XDECREF(cpy_r_r35.f0);
+    CPy_XDECREF(cpy_r_r35.f1);
+    CPy_XDECREF(cpy_r_r35.f2);
 CPyL34: ;
-    if (cpy_r_r34.f0 == NULL) goto CPyL36;
-    CPy_RestoreExcInfo(cpy_r_r34);
-    CPy_XDECREF(cpy_r_r34.f0);
-    CPy_XDECREF(cpy_r_r34.f1);
-    CPy_XDECREF(cpy_r_r34.f2);
-CPyL36: ;
-    cpy_r_r41 = CPy_KeepPropagating();
-    if (!cpy_r_r41) goto CPyL39;
+    cpy_r_r42 = CPy_KeepPropagating();
+    if (!cpy_r_r42) goto CPyL37;
     CPy_Unreachable();
-CPyL38: ;
-    cpy_r_r42 = Py_None;
-    return cpy_r_r42;
-CPyL39: ;
-    cpy_r_r43 = NULL;
+CPyL36: ;
+    cpy_r_r43 = Py_None;
     return cpy_r_r43;
-CPyL40: ;
+CPyL37: ;
+    cpy_r_r44 = NULL;
+    return cpy_r_r44;
+CPyL38: ;
     CPy_DecRef(cpy_r_r0);
     goto CPyL2;
+CPyL39: ;
+    CPy_DecRef(cpy_r_r0);
+    goto CPyL37;
+CPyL40: ;
+    CPy_DecRef(cpy_r_r0);
+    CPy_DecRef(cpy_r_r8);
+    CPy_DecRef(cpy_r_r9);
+    goto CPyL37;
 CPyL41: ;
     CPy_DecRef(cpy_r_r0);
-    goto CPyL5;
-CPyL42: ;
-    CPy_DecRef(cpy_r_r0);
-    goto CPyL39;
-CPyL43: ;
-    CPy_DecRef(cpy_r_r0);
-    CPy_DecRef(cpy_r_r7);
     CPy_DecRef(cpy_r_r8);
-    goto CPyL39;
-CPyL44: ;
-    CPy_DecRef(cpy_r_r0);
-    CPy_DecRef(cpy_r_r7);
-    CPy_DecRef(cpy_r_r10);
-    goto CPyL39;
-CPyL45: ;
-    CPy_DECREF(cpy_r_r15);
-    goto CPyL11;
-CPyL46: ;
-    CPy_DecRef(cpy_r_r22);
+    CPy_DecRef(cpy_r_r11);
+    goto CPyL37;
+CPyL42: ;
+    CPy_DECREF(cpy_r_r16);
+    goto CPyL9;
+CPyL43: ;
     CPy_DecRef(cpy_r_r23);
     CPy_DecRef(cpy_r_r24);
-    goto CPyL21;
-CPyL47: ;
-    CPy_DecRef(cpy_r_r7);
-    CPy_DecRef(cpy_r_r10);
-    CPy_DecRef(cpy_r_r20.f0);
-    CPy_DecRef(cpy_r_r20.f1);
-    CPy_DecRef(cpy_r_r20.f2);
+    CPy_DecRef(cpy_r_r25);
     goto CPyL19;
+CPyL44: ;
+    CPy_DecRef(cpy_r_r8);
+    CPy_DecRef(cpy_r_r11);
+    CPy_DecRef(cpy_r_r21.f0);
+    CPy_DecRef(cpy_r_r21.f1);
+    CPy_DecRef(cpy_r_r21.f2);
+    goto CPyL17;
+CPyL45: ;
+    CPy_DecRef(cpy_r_r8);
+    CPy_DecRef(cpy_r_r11);
+    goto CPyL20;
+CPyL46: ;
+    CPy_DECREF(cpy_r_r8);
+    CPy_DECREF(cpy_r_r11);
+    goto CPyL27;
+CPyL47: ;
+    CPy_DecRef(cpy_r_r8);
+    CPy_XDecRef(cpy_r_r20);
+    goto CPyL32;
 CPyL48: ;
-    CPy_DecRef(cpy_r_r7);
-    CPy_DecRef(cpy_r_r10);
-    goto CPyL22;
+    CPy_DECREF(cpy_r_r41);
+    goto CPyL26;
 CPyL49: ;
-    CPy_DECREF(cpy_r_r7);
-    CPy_DECREF(cpy_r_r10);
-    goto CPyL29;
-CPyL50: ;
-    CPy_DecRef(cpy_r_r7);
-    CPy_XDecRef(cpy_r_r19);
-    goto CPyL34;
-CPyL51: ;
-    CPy_DECREF(cpy_r_r40);
+    CPy_XDECREF(cpy_r_r20);
     goto CPyL28;
-CPyL52: ;
-    CPy_XDECREF(cpy_r_r19);
-    goto CPyL30;
-CPyL53: ;
-    CPy_XDECREF(cpy_r_r34.f0);
-    CPy_XDECREF(cpy_r_r34.f1);
-    CPy_XDECREF(cpy_r_r34.f2);
-    goto CPyL31;
+CPyL50: ;
+    CPy_XDECREF(cpy_r_r35.f0);
+    CPy_XDECREF(cpy_r_r35.f1);
+    CPy_XDECREF(cpy_r_r35.f2);
+    goto CPyL29;
 }
 
 PyObject *CPyPy_numeric___f_scale_places_obj_____call__(PyObject *self, PyObject *const *args, size_t nargs, PyObject *kwnames) {
@@ -13175,7 +13149,7 @@ PyObject *CPyPy_numeric___f_scale_places_obj_____call__(PyObject *self, PyObject
     PyObject *retval = CPyDef_numeric___f_scale_places_obj_____call__(arg___mypyc_self__, arg_x);
     return retval;
 fail: ;
-    CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 105, CPyStatic_numeric___globals);
+    CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "f", 106, CPyStatic_numeric___globals);
     return NULL;
 }
 
@@ -13216,72 +13190,73 @@ PyObject *CPyDef_numeric___scale_places(CPyTagged cpy_r_places) {
     PyObject *cpy_r_r36;
     char cpy_r_r37;
     PyObject *cpy_r_r38;
-    char cpy_r_r39;
-    PyObject **cpy_r_r41;
-    PyObject *cpy_r_r42;
+    PyObject *cpy_r_r39;
+    PyObject *cpy_r_r40;
+    PyObject **cpy_r_r42;
     PyObject *cpy_r_r43;
     PyObject *cpy_r_r44;
     PyObject *cpy_r_r45;
     PyObject *cpy_r_r46;
     PyObject *cpy_r_r47;
-    PyObject **cpy_r_r49;
-    PyObject *cpy_r_r50;
-    char cpy_r_r51;
-    PyObject *cpy_r_r52;
-    char cpy_r_r53;
-    CPyTagged cpy_r_r54;
-    PyObject *cpy_r_r55;
+    PyObject *cpy_r_r48;
+    PyObject **cpy_r_r50;
+    PyObject *cpy_r_r51;
+    char cpy_r_r52;
+    PyObject *cpy_r_r53;
+    char cpy_r_r54;
+    CPyTagged cpy_r_r55;
     PyObject *cpy_r_r56;
-    char cpy_r_r57;
-    tuple_T3OOO cpy_r_r58;
+    PyObject *cpy_r_r57;
+    char cpy_r_r58;
     tuple_T3OOO cpy_r_r59;
-    PyObject *cpy_r_r60;
+    tuple_T3OOO cpy_r_r60;
     PyObject *cpy_r_r61;
     PyObject *cpy_r_r62;
-    PyObject **cpy_r_r64;
-    PyObject *cpy_r_r65;
-    int32_t cpy_r_r66;
-    char cpy_r_r67;
+    PyObject *cpy_r_r63;
+    PyObject **cpy_r_r65;
+    PyObject *cpy_r_r66;
+    int32_t cpy_r_r67;
     char cpy_r_r68;
     char cpy_r_r69;
-    tuple_T3OOO cpy_r_r70;
+    char cpy_r_r70;
     tuple_T3OOO cpy_r_r71;
     tuple_T3OOO cpy_r_r72;
-    PyObject *cpy_r_r73;
-    PyObject **cpy_r_r75;
-    PyObject *cpy_r_r76;
-    char cpy_r_r77;
-    PyObject *cpy_r_r78;
-    char cpy_r_r79;
+    tuple_T3OOO cpy_r_r73;
+    PyObject *cpy_r_r74;
+    PyObject **cpy_r_r76;
+    PyObject *cpy_r_r77;
+    char cpy_r_r78;
+    PyObject *cpy_r_r79;
+    char cpy_r_r80;
     PyObject *cpy_r_f;
-    int64_t cpy_r_r80;
-    char cpy_r_r81;
-    int64_t cpy_r_r82;
-    char cpy_r_r83;
+    int64_t cpy_r_r81;
+    char cpy_r_r82;
+    int64_t cpy_r_r83;
     char cpy_r_r84;
     char cpy_r_r85;
-    PyObject *cpy_r_r86;
+    char cpy_r_r86;
     PyObject *cpy_r_r87;
     PyObject *cpy_r_r88;
     PyObject *cpy_r_r89;
     PyObject *cpy_r_r90;
-    CPyTagged cpy_r_r91;
-    PyObject *cpy_r_r92;
+    PyObject *cpy_r_r91;
+    CPyTagged cpy_r_r92;
     PyObject *cpy_r_r93;
-    PyObject *cpy_r_places_repr;
     PyObject *cpy_r_r94;
+    PyObject *cpy_r_places_repr;
     PyObject *cpy_r_r95;
     PyObject *cpy_r_r96;
-    int32_t cpy_r_r97;
-    char cpy_r_r98;
-    PyObject *cpy_r_r99;
-    int32_t cpy_r_r100;
-    char cpy_r_r101;
-    PyObject *cpy_r_r102;
+    PyObject *cpy_r_r97;
+    int32_t cpy_r_r98;
+    char cpy_r_r99;
+    PyObject *cpy_r_r100;
+    int32_t cpy_r_r101;
+    char cpy_r_r102;
+    PyObject *cpy_r_r103;
     cpy_r_r0 = CPyDef_numeric___scale_places_env();
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 91, CPyStatic_numeric___globals);
-        goto CPyL62;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 92, CPyStatic_numeric___globals);
+        goto CPyL60;
     }
     CPyTagged_INCREF(cpy_r_places);
     cpy_r_r1 = CPyTagged_StealAsObject(cpy_r_places);
@@ -13290,10 +13265,10 @@ PyObject *CPyDef_numeric___scale_places(CPyTagged cpy_r_places) {
     if (cpy_r_r2) {
         goto CPyL10;
     } else
-        goto CPyL63;
+        goto CPyL61;
 CPyL2: ;
     cpy_r_r3 = CPyStatics[43]; /* '' */
-    cpy_r_r4 = CPyStatics[189]; /* 'Argument `places` must be int.  Got value ' */
+    cpy_r_r4 = CPyStatics[190]; /* 'Argument `places` must be int.  Got value ' */
     cpy_r_r5 = CPyStatics[81]; /* '{:{}}' */
     CPyTagged_INCREF(cpy_r_places);
     cpy_r_r6 = CPyTagged_StealAsObject(cpy_r_places);
@@ -13303,11 +13278,11 @@ CPyL2: ;
     cpy_r_r10 = (PyObject **)&cpy_r_r9;
     cpy_r_r11 = PyObject_VectorcallMethod(cpy_r_r8, cpy_r_r10, 9223372036854775811ULL, 0);
     if (unlikely(cpy_r_r11 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 98, CPyStatic_numeric___globals);
-        goto CPyL64;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 99, CPyStatic_numeric___globals);
+        goto CPyL62;
     }
     CPy_DECREF(cpy_r_r6);
-    cpy_r_r12 = CPyStatics[190]; /* ' of type ' */
+    cpy_r_r12 = CPyStatics[191]; /* ' of type ' */
     cpy_r_r13 = CPyStatics[81]; /* '{:{}}' */
     CPyTagged_INCREF(cpy_r_places);
     cpy_r_r14 = CPyTagged_StealAsObject(cpy_r_places);
@@ -13319,15 +13294,15 @@ CPyL2: ;
     cpy_r_r19 = (PyObject **)&cpy_r_r18;
     cpy_r_r20 = PyObject_VectorcallMethod(cpy_r_r17, cpy_r_r19, 9223372036854775811ULL, 0);
     if (unlikely(cpy_r_r20 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 99, CPyStatic_numeric___globals);
-        goto CPyL65;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 100, CPyStatic_numeric___globals);
+        goto CPyL63;
     }
     CPy_DECREF(cpy_r_r15);
-    cpy_r_r21 = CPyStatics[191]; /* '.' */
+    cpy_r_r21 = CPyStatics[192]; /* '.' */
     cpy_r_r22 = PyList_New(5);
     if (unlikely(cpy_r_r22 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 98, CPyStatic_numeric___globals);
-        goto CPyL66;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 99, CPyStatic_numeric___globals);
+        goto CPyL64;
     }
     cpy_r_r23 = (CPyPtr)&((PyListObject *)cpy_r_r22)->ob_item;
     cpy_r_r24 = *(CPyPtr *)cpy_r_r23;
@@ -13346,405 +13321,396 @@ CPyL2: ;
     cpy_r_r29 = PyUnicode_Join(cpy_r_r3, cpy_r_r22);
     CPy_DECREF_NO_IMM(cpy_r_r22);
     if (unlikely(cpy_r_r29 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 98, CPyStatic_numeric___globals);
-        goto CPyL62;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 99, CPyStatic_numeric___globals);
+        goto CPyL60;
     }
     cpy_r_r30 = CPyModule_builtins;
     cpy_r_r31 = CPyStatics[87]; /* 'ValueError' */
     cpy_r_r32 = CPyObject_GetAttr(cpy_r_r30, cpy_r_r31);
     if (unlikely(cpy_r_r32 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 97, CPyStatic_numeric___globals);
-        goto CPyL67;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 98, CPyStatic_numeric___globals);
+        goto CPyL65;
     }
     PyObject *cpy_r_r33[1] = {cpy_r_r29};
     cpy_r_r34 = (PyObject **)&cpy_r_r33;
     cpy_r_r35 = PyObject_Vectorcall(cpy_r_r32, cpy_r_r34, 1, 0);
     CPy_DECREF(cpy_r_r32);
     if (unlikely(cpy_r_r35 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 97, CPyStatic_numeric___globals);
-        goto CPyL67;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 98, CPyStatic_numeric___globals);
+        goto CPyL65;
     }
     CPy_DECREF(cpy_r_r29);
     CPy_Raise(cpy_r_r35);
     CPy_DECREF(cpy_r_r35);
     if (unlikely(!0)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 97, CPyStatic_numeric___globals);
-        goto CPyL62;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 98, CPyStatic_numeric___globals);
+        goto CPyL60;
     }
     CPy_Unreachable();
 CPyL10: ;
     cpy_r_r36 = CPyStatic_numeric___abi_decimal_context;
     if (unlikely(cpy_r_r36 == NULL)) {
-        goto CPyL68;
+        goto CPyL66;
     } else
         goto CPyL13;
 CPyL11: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"abi_decimal_context\" was not set");
     cpy_r_r37 = 0;
     if (unlikely(!cpy_r_r37)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 102, CPyStatic_numeric___globals);
-        goto CPyL62;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 103, CPyStatic_numeric___globals);
+        goto CPyL60;
     }
     CPy_Unreachable();
 CPyL13: ;
-    cpy_r_r38 = CPyStatic_numeric___decimal_localcontext;
-    if (unlikely(cpy_r_r38 == NULL)) {
+    cpy_r_r38 = CPyModule_decimal;
+    cpy_r_r39 = CPyStatics[187]; /* 'localcontext' */
+    cpy_r_r40 = CPyObject_GetAttr(cpy_r_r38, cpy_r_r39);
+    if (unlikely(cpy_r_r40 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 103, CPyStatic_numeric___globals);
+        goto CPyL67;
+    }
+    PyObject *cpy_r_r41[1] = {cpy_r_r36};
+    cpy_r_r42 = (PyObject **)&cpy_r_r41;
+    cpy_r_r43 = PyObject_Vectorcall(cpy_r_r40, cpy_r_r42, 1, 0);
+    CPy_DECREF(cpy_r_r40);
+    if (unlikely(cpy_r_r43 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 103, CPyStatic_numeric___globals);
+        goto CPyL67;
+    }
+    cpy_r_r44 = CPy_TYPE(cpy_r_r43);
+    cpy_r_r45 = CPyStatics[188]; /* '__exit__' */
+    cpy_r_r46 = CPyObject_GetAttr(cpy_r_r44, cpy_r_r45);
+    if (unlikely(cpy_r_r46 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 103, CPyStatic_numeric___globals);
+        goto CPyL68;
+    }
+    cpy_r_r47 = CPyStatics[189]; /* '__enter__' */
+    cpy_r_r48 = CPyObject_GetAttr(cpy_r_r44, cpy_r_r47);
+    CPy_DECREF(cpy_r_r44);
+    if (unlikely(cpy_r_r48 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 103, CPyStatic_numeric___globals);
+        goto CPyL69;
+    }
+    PyObject *cpy_r_r49[1] = {cpy_r_r43};
+    cpy_r_r50 = (PyObject **)&cpy_r_r49;
+    cpy_r_r51 = PyObject_Vectorcall(cpy_r_r48, cpy_r_r50, 1, 0);
+    CPy_DECREF(cpy_r_r48);
+    if (unlikely(cpy_r_r51 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 103, CPyStatic_numeric___globals);
         goto CPyL69;
     } else
-        goto CPyL16;
-CPyL14: ;
-    PyErr_SetString(PyExc_NameError, "value for final name \"decimal_localcontext\" was not set");
-    cpy_r_r39 = 0;
-    if (unlikely(!cpy_r_r39)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 102, CPyStatic_numeric___globals);
-        goto CPyL62;
-    }
-    CPy_Unreachable();
-CPyL16: ;
-    PyObject *cpy_r_r40[1] = {cpy_r_r36};
-    cpy_r_r41 = (PyObject **)&cpy_r_r40;
-    cpy_r_r42 = PyObject_Vectorcall(cpy_r_r38, cpy_r_r41, 1, 0);
-    if (unlikely(cpy_r_r42 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 102, CPyStatic_numeric___globals);
         goto CPyL70;
-    }
-    cpy_r_r43 = CPy_TYPE(cpy_r_r42);
-    cpy_r_r44 = CPyStatics[187]; /* '__exit__' */
-    cpy_r_r45 = CPyObject_GetAttr(cpy_r_r43, cpy_r_r44);
-    if (unlikely(cpy_r_r45 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 102, CPyStatic_numeric___globals);
-        goto CPyL71;
-    }
-    cpy_r_r46 = CPyStatics[188]; /* '__enter__' */
-    cpy_r_r47 = CPyObject_GetAttr(cpy_r_r43, cpy_r_r46);
-    CPy_DECREF(cpy_r_r43);
-    if (unlikely(cpy_r_r47 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 102, CPyStatic_numeric___globals);
-        goto CPyL72;
-    }
-    PyObject *cpy_r_r48[1] = {cpy_r_r42};
-    cpy_r_r49 = (PyObject **)&cpy_r_r48;
-    cpy_r_r50 = PyObject_Vectorcall(cpy_r_r47, cpy_r_r49, 1, 0);
-    CPy_DECREF(cpy_r_r47);
-    if (unlikely(cpy_r_r50 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 102, CPyStatic_numeric___globals);
-        goto CPyL72;
-    } else
-        goto CPyL73;
-CPyL20: ;
-    cpy_r_r51 = 1;
-    cpy_r_r52 = CPyStatic_numeric___TEN;
-    if (likely(cpy_r_r52 != NULL)) goto CPyL24;
+CPyL18: ;
+    cpy_r_r52 = 1;
+    cpy_r_r53 = CPyStatic_numeric___TEN;
+    if (likely(cpy_r_r53 != NULL)) goto CPyL22;
     PyErr_SetString(PyExc_NameError, "value for final name \"TEN\" was not set");
-    cpy_r_r53 = 0;
-    if (unlikely(!cpy_r_r53)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 103, CPyStatic_numeric___globals);
-        goto CPyL26;
+    cpy_r_r54 = 0;
+    if (unlikely(!cpy_r_r54)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 104, CPyStatic_numeric___globals);
+        goto CPyL24;
     } else
-        goto CPyL74;
-CPyL23: ;
+        goto CPyL71;
+CPyL21: ;
     CPy_Unreachable();
-CPyL24: ;
-    cpy_r_r54 = CPyTagged_Negate(cpy_r_places);
-    cpy_r_r55 = CPyTagged_StealAsObject(cpy_r_r54);
-    cpy_r_r56 = CPyNumber_Power(cpy_r_r52, cpy_r_r55);
-    CPy_DECREF(cpy_r_r55);
-    if (unlikely(cpy_r_r56 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 103, CPyStatic_numeric___globals);
-        goto CPyL26;
+CPyL22: ;
+    cpy_r_r55 = CPyTagged_Negate(cpy_r_places);
+    cpy_r_r56 = CPyTagged_StealAsObject(cpy_r_r55);
+    cpy_r_r57 = CPyNumber_Power(cpy_r_r53, cpy_r_r56);
+    CPy_DECREF(cpy_r_r56);
+    if (unlikely(cpy_r_r57 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 104, CPyStatic_numeric___globals);
+        goto CPyL24;
     }
     if (((faster_eth_abi___utils___numeric___scale_places_envObject *)cpy_r_r0)->_scaling_factor != NULL) {
         CPy_DECREF(((faster_eth_abi___utils___numeric___scale_places_envObject *)cpy_r_r0)->_scaling_factor);
     }
-    ((faster_eth_abi___utils___numeric___scale_places_envObject *)cpy_r_r0)->_scaling_factor = cpy_r_r56;
-    cpy_r_r57 = 1;
-    if (unlikely(!cpy_r_r57)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 103, CPyStatic_numeric___globals);
+    ((faster_eth_abi___utils___numeric___scale_places_envObject *)cpy_r_r0)->_scaling_factor = cpy_r_r57;
+    cpy_r_r58 = 1;
+    if (unlikely(!cpy_r_r58)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 104, CPyStatic_numeric___globals);
     } else
-        goto CPyL34;
-CPyL26: ;
-    cpy_r_r58 = CPy_CatchError();
-    cpy_r_r51 = 0;
-    cpy_r_r59 = CPy_GetExcInfo();
-    cpy_r_r60 = cpy_r_r59.f0;
-    CPy_INCREF(cpy_r_r60);
-    cpy_r_r61 = cpy_r_r59.f1;
+        goto CPyL32;
+CPyL24: ;
+    cpy_r_r59 = CPy_CatchError();
+    cpy_r_r52 = 0;
+    cpy_r_r60 = CPy_GetExcInfo();
+    cpy_r_r61 = cpy_r_r60.f0;
     CPy_INCREF(cpy_r_r61);
-    cpy_r_r62 = cpy_r_r59.f2;
+    cpy_r_r62 = cpy_r_r60.f1;
     CPy_INCREF(cpy_r_r62);
+    cpy_r_r63 = cpy_r_r60.f2;
+    CPy_INCREF(cpy_r_r63);
+    CPy_DecRef(cpy_r_r60.f0);
+    CPy_DecRef(cpy_r_r60.f1);
+    CPy_DecRef(cpy_r_r60.f2);
+    PyObject *cpy_r_r64[4] = {cpy_r_r43, cpy_r_r61, cpy_r_r62, cpy_r_r63};
+    cpy_r_r65 = (PyObject **)&cpy_r_r64;
+    cpy_r_r66 = PyObject_Vectorcall(cpy_r_r46, cpy_r_r65, 4, 0);
+    if (unlikely(cpy_r_r66 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 103, CPyStatic_numeric___globals);
+        goto CPyL72;
+    }
+    CPy_DecRef(cpy_r_r61);
+    CPy_DecRef(cpy_r_r62);
+    CPy_DecRef(cpy_r_r63);
+    cpy_r_r67 = PyObject_IsTrue(cpy_r_r66);
+    CPy_DecRef(cpy_r_r66);
+    cpy_r_r68 = cpy_r_r67 >= 0;
+    if (unlikely(!cpy_r_r68)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 103, CPyStatic_numeric___globals);
+        goto CPyL30;
+    }
+    cpy_r_r69 = cpy_r_r67;
+    if (cpy_r_r69) goto CPyL29;
+    CPy_Reraise();
+    if (!0) {
+        goto CPyL30;
+    } else
+        goto CPyL73;
+CPyL28: ;
+    CPy_Unreachable();
+CPyL29: ;
+    CPy_RestoreExcInfo(cpy_r_r59);
     CPy_DecRef(cpy_r_r59.f0);
     CPy_DecRef(cpy_r_r59.f1);
     CPy_DecRef(cpy_r_r59.f2);
-    PyObject *cpy_r_r63[4] = {cpy_r_r42, cpy_r_r60, cpy_r_r61, cpy_r_r62};
-    cpy_r_r64 = (PyObject **)&cpy_r_r63;
-    cpy_r_r65 = PyObject_Vectorcall(cpy_r_r45, cpy_r_r64, 4, 0);
-    if (unlikely(cpy_r_r65 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 102, CPyStatic_numeric___globals);
-        goto CPyL75;
-    }
-    CPy_DecRef(cpy_r_r60);
-    CPy_DecRef(cpy_r_r61);
-    CPy_DecRef(cpy_r_r62);
-    cpy_r_r66 = PyObject_IsTrue(cpy_r_r65);
-    CPy_DecRef(cpy_r_r65);
-    cpy_r_r67 = cpy_r_r66 >= 0;
-    if (unlikely(!cpy_r_r67)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 102, CPyStatic_numeric___globals);
-        goto CPyL32;
-    }
-    cpy_r_r68 = cpy_r_r66;
-    if (cpy_r_r68) goto CPyL31;
-    CPy_Reraise();
-    if (!0) {
-        goto CPyL32;
-    } else
-        goto CPyL76;
+    goto CPyL32;
 CPyL30: ;
-    CPy_Unreachable();
+    CPy_RestoreExcInfo(cpy_r_r59);
+    CPy_DecRef(cpy_r_r59.f0);
+    CPy_DecRef(cpy_r_r59.f1);
+    CPy_DecRef(cpy_r_r59.f2);
+    cpy_r_r70 = CPy_KeepPropagating();
+    if (!cpy_r_r70) {
+        goto CPyL33;
+    } else
+        goto CPyL74;
 CPyL31: ;
-    CPy_RestoreExcInfo(cpy_r_r58);
-    CPy_DecRef(cpy_r_r58.f0);
-    CPy_DecRef(cpy_r_r58.f1);
-    CPy_DecRef(cpy_r_r58.f2);
-    goto CPyL34;
+    CPy_Unreachable();
 CPyL32: ;
-    CPy_RestoreExcInfo(cpy_r_r58);
-    CPy_DecRef(cpy_r_r58.f0);
-    CPy_DecRef(cpy_r_r58.f1);
-    CPy_DecRef(cpy_r_r58.f2);
-    cpy_r_r69 = CPy_KeepPropagating();
-    if (!cpy_r_r69) {
-        goto CPyL35;
+    tuple_T3OOO __tmp98 = { NULL, NULL, NULL };
+    cpy_r_r71 = __tmp98;
+    cpy_r_r72 = cpy_r_r71;
+    goto CPyL34;
+CPyL33: ;
+    cpy_r_r73 = CPy_CatchError();
+    cpy_r_r72 = cpy_r_r73;
+CPyL34: ;
+    if (!cpy_r_r52) goto CPyL75;
+    cpy_r_r74 = (PyObject *)&_Py_NoneStruct;
+    PyObject *cpy_r_r75[4] = {cpy_r_r43, cpy_r_r74, cpy_r_r74, cpy_r_r74};
+    cpy_r_r76 = (PyObject **)&cpy_r_r75;
+    cpy_r_r77 = PyObject_Vectorcall(cpy_r_r46, cpy_r_r76, 4, 0);
+    CPy_DECREF(cpy_r_r46);
+    if (unlikely(cpy_r_r77 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 103, CPyStatic_numeric___globals);
+        goto CPyL76;
     } else
         goto CPyL77;
-CPyL33: ;
-    CPy_Unreachable();
-CPyL34: ;
-    tuple_T3OOO __tmp98 = { NULL, NULL, NULL };
-    cpy_r_r70 = __tmp98;
-    cpy_r_r71 = cpy_r_r70;
-    goto CPyL36;
-CPyL35: ;
-    cpy_r_r72 = CPy_CatchError();
-    cpy_r_r71 = cpy_r_r72;
 CPyL36: ;
-    if (!cpy_r_r51) goto CPyL78;
-    cpy_r_r73 = (PyObject *)&_Py_NoneStruct;
-    PyObject *cpy_r_r74[4] = {cpy_r_r42, cpy_r_r73, cpy_r_r73, cpy_r_r73};
-    cpy_r_r75 = (PyObject **)&cpy_r_r74;
-    cpy_r_r76 = PyObject_Vectorcall(cpy_r_r45, cpy_r_r75, 4, 0);
-    CPy_DECREF(cpy_r_r45);
-    if (unlikely(cpy_r_r76 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 102, CPyStatic_numeric___globals);
-        goto CPyL79;
+    CPy_DECREF(cpy_r_r43);
+CPyL37: ;
+    if (cpy_r_r72.f0 == NULL) {
+        goto CPyL44;
     } else
-        goto CPyL80;
+        goto CPyL78;
 CPyL38: ;
-    CPy_DECREF(cpy_r_r42);
-CPyL39: ;
-    if (cpy_r_r71.f0 == NULL) {
-        goto CPyL46;
-    } else
-        goto CPyL81;
-CPyL40: ;
     CPy_Reraise();
     if (!0) {
-        goto CPyL42;
+        goto CPyL40;
     } else
-        goto CPyL82;
-CPyL41: ;
+        goto CPyL79;
+CPyL39: ;
     CPy_Unreachable();
+CPyL40: ;
+    if (cpy_r_r72.f0 == NULL) goto CPyL42;
+    CPy_RestoreExcInfo(cpy_r_r72);
+    CPy_XDECREF(cpy_r_r72.f0);
+    CPy_XDECREF(cpy_r_r72.f1);
+    CPy_XDECREF(cpy_r_r72.f2);
 CPyL42: ;
-    if (cpy_r_r71.f0 == NULL) goto CPyL44;
-    CPy_RestoreExcInfo(cpy_r_r71);
-    CPy_XDECREF(cpy_r_r71.f0);
-    CPy_XDECREF(cpy_r_r71.f1);
-    CPy_XDECREF(cpy_r_r71.f2);
-CPyL44: ;
-    cpy_r_r77 = CPy_KeepPropagating();
-    if (!cpy_r_r77) goto CPyL62;
+    cpy_r_r78 = CPy_KeepPropagating();
+    if (!cpy_r_r78) goto CPyL60;
     CPy_Unreachable();
-CPyL46: ;
-    cpy_r_r78 = CPyDef_numeric___f_scale_places_obj();
-    if (unlikely(cpy_r_r78 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 105, CPyStatic_numeric___globals);
-        goto CPyL70;
+CPyL44: ;
+    cpy_r_r79 = CPyDef_numeric___f_scale_places_obj();
+    if (unlikely(cpy_r_r79 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 106, CPyStatic_numeric___globals);
+        goto CPyL67;
     }
-    if (((faster_eth_abi___utils___numeric___f_scale_places_objObject *)cpy_r_r78)->___mypyc_env__ != NULL) {
-        CPy_DECREF_NO_IMM(((faster_eth_abi___utils___numeric___f_scale_places_objObject *)cpy_r_r78)->___mypyc_env__);
+    if (((faster_eth_abi___utils___numeric___f_scale_places_objObject *)cpy_r_r79)->___mypyc_env__ != NULL) {
+        CPy_DECREF_NO_IMM(((faster_eth_abi___utils___numeric___f_scale_places_objObject *)cpy_r_r79)->___mypyc_env__);
     }
-    ((faster_eth_abi___utils___numeric___f_scale_places_objObject *)cpy_r_r78)->___mypyc_env__ = cpy_r_r0;
-    cpy_r_r79 = 1;
-    if (unlikely(!cpy_r_r79)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 105, CPyStatic_numeric___globals);
-        goto CPyL83;
+    ((faster_eth_abi___utils___numeric___f_scale_places_objObject *)cpy_r_r79)->___mypyc_env__ = cpy_r_r0;
+    cpy_r_r80 = 1;
+    if (unlikely(!cpy_r_r80)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 106, CPyStatic_numeric___globals);
+        goto CPyL80;
     }
-    cpy_r_f = cpy_r_r78;
-    cpy_r_r80 = cpy_r_places & 1;
-    cpy_r_r81 = cpy_r_r80 != 0;
-    if (cpy_r_r81) goto CPyL50;
-    cpy_r_r82 = 0 & 1;
-    cpy_r_r83 = cpy_r_r82 != 0;
-    if (!cpy_r_r83) goto CPyL51;
-CPyL50: ;
-    cpy_r_r84 = CPyTagged_IsLt_(0, cpy_r_places);
-    if (cpy_r_r84) {
-        goto CPyL52;
+    cpy_r_f = cpy_r_r79;
+    cpy_r_r81 = cpy_r_places & 1;
+    cpy_r_r82 = cpy_r_r81 != 0;
+    if (cpy_r_r82) goto CPyL48;
+    cpy_r_r83 = 0 & 1;
+    cpy_r_r84 = cpy_r_r83 != 0;
+    if (!cpy_r_r84) goto CPyL49;
+CPyL48: ;
+    cpy_r_r85 = CPyTagged_IsLt_(0, cpy_r_places);
+    if (cpy_r_r85) {
+        goto CPyL50;
     } else
-        goto CPyL55;
-CPyL51: ;
-    cpy_r_r85 = (Py_ssize_t)cpy_r_places > (Py_ssize_t)0;
-    if (!cpy_r_r85) goto CPyL55;
-CPyL52: ;
-    cpy_r_r86 = CPyStatics[192]; /* 'Eneg' */
-    cpy_r_r87 = CPyTagged_Str(cpy_r_places);
-    if (unlikely(cpy_r_r87 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 109, CPyStatic_numeric___globals);
-        goto CPyL84;
-    }
-    cpy_r_r88 = CPyStr_Build(2, cpy_r_r86, cpy_r_r87);
-    CPy_DECREF(cpy_r_r87);
+        goto CPyL53;
+CPyL49: ;
+    cpy_r_r86 = (Py_ssize_t)cpy_r_places > (Py_ssize_t)0;
+    if (!cpy_r_r86) goto CPyL53;
+CPyL50: ;
+    cpy_r_r87 = CPyStatics[193]; /* 'Eneg' */
+    cpy_r_r88 = CPyTagged_Str(cpy_r_places);
     if (unlikely(cpy_r_r88 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 109, CPyStatic_numeric___globals);
-        goto CPyL84;
-    }
-    cpy_r_r89 = cpy_r_r88;
-    goto CPyL58;
-CPyL55: ;
-    cpy_r_r90 = CPyStatics[193]; /* 'Epos' */
-    cpy_r_r91 = CPyTagged_Negate(cpy_r_places);
-    cpy_r_r92 = CPyTagged_Str(cpy_r_r91);
-    CPyTagged_DECREF(cpy_r_r91);
-    if (unlikely(cpy_r_r92 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 109, CPyStatic_numeric___globals);
-        goto CPyL84;
-    }
-    cpy_r_r93 = CPyStr_Build(2, cpy_r_r90, cpy_r_r92);
-    CPy_DECREF(cpy_r_r92);
-    if (unlikely(cpy_r_r93 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 109, CPyStatic_numeric___globals);
-        goto CPyL84;
-    }
-    cpy_r_r89 = cpy_r_r93;
-CPyL58: ;
-    cpy_r_places_repr = cpy_r_r89;
-    cpy_r_r94 = CPyStatics[194]; /* 'scale_by_' */
-    cpy_r_r95 = CPyStr_Build(2, cpy_r_r94, cpy_r_places_repr);
-    CPy_DECREF(cpy_r_places_repr);
-    if (unlikely(cpy_r_r95 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 110, CPyStatic_numeric___globals);
-        goto CPyL84;
+        goto CPyL81;
     }
-    cpy_r_r96 = CPyStatics[195]; /* '__name__' */
-    cpy_r_r97 = PyObject_SetAttr(cpy_r_f, cpy_r_r96, cpy_r_r95);
-    cpy_r_r98 = cpy_r_r97 >= 0;
-    if (unlikely(!cpy_r_r98)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 112, CPyStatic_numeric___globals);
-        goto CPyL85;
+    cpy_r_r89 = CPyStr_Build(2, cpy_r_r87, cpy_r_r88);
+    CPy_DECREF(cpy_r_r88);
+    if (unlikely(cpy_r_r89 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 110, CPyStatic_numeric___globals);
+        goto CPyL81;
     }
-    cpy_r_r99 = CPyStatics[196]; /* '__qualname__' */
-    cpy_r_r100 = PyObject_SetAttr(cpy_r_f, cpy_r_r99, cpy_r_r95);
-    CPy_DECREF(cpy_r_r95);
-    cpy_r_r101 = cpy_r_r100 >= 0;
-    if (unlikely(!cpy_r_r101)) {
+    cpy_r_r90 = cpy_r_r89;
+    goto CPyL56;
+CPyL53: ;
+    cpy_r_r91 = CPyStatics[194]; /* 'Epos' */
+    cpy_r_r92 = CPyTagged_Negate(cpy_r_places);
+    cpy_r_r93 = CPyTagged_Str(cpy_r_r92);
+    CPyTagged_DECREF(cpy_r_r92);
+    if (unlikely(cpy_r_r93 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 110, CPyStatic_numeric___globals);
+        goto CPyL81;
+    }
+    cpy_r_r94 = CPyStr_Build(2, cpy_r_r91, cpy_r_r93);
+    CPy_DECREF(cpy_r_r93);
+    if (unlikely(cpy_r_r94 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 110, CPyStatic_numeric___globals);
+        goto CPyL81;
+    }
+    cpy_r_r90 = cpy_r_r94;
+CPyL56: ;
+    cpy_r_places_repr = cpy_r_r90;
+    cpy_r_r95 = CPyStatics[195]; /* 'scale_by_' */
+    cpy_r_r96 = CPyStr_Build(2, cpy_r_r95, cpy_r_places_repr);
+    CPy_DECREF(cpy_r_places_repr);
+    if (unlikely(cpy_r_r96 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 111, CPyStatic_numeric___globals);
+        goto CPyL81;
+    }
+    cpy_r_r97 = CPyStatics[196]; /* '__name__' */
+    cpy_r_r98 = PyObject_SetAttr(cpy_r_f, cpy_r_r97, cpy_r_r96);
+    cpy_r_r99 = cpy_r_r98 >= 0;
+    if (unlikely(!cpy_r_r99)) {
         CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 113, CPyStatic_numeric___globals);
-        goto CPyL84;
+        goto CPyL82;
+    }
+    cpy_r_r100 = CPyStatics[197]; /* '__qualname__' */
+    cpy_r_r101 = PyObject_SetAttr(cpy_r_f, cpy_r_r100, cpy_r_r96);
+    CPy_DECREF(cpy_r_r96);
+    cpy_r_r102 = cpy_r_r101 >= 0;
+    if (unlikely(!cpy_r_r102)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 114, CPyStatic_numeric___globals);
+        goto CPyL81;
     }
     return cpy_r_f;
-CPyL62: ;
-    cpy_r_r102 = NULL;
-    return cpy_r_r102;
-CPyL63: ;
+CPyL60: ;
+    cpy_r_r103 = NULL;
+    return cpy_r_r103;
+CPyL61: ;
     CPy_DECREF_NO_IMM(cpy_r_r0);
     goto CPyL2;
-CPyL64: ;
+CPyL62: ;
     CPy_DecRef(cpy_r_r6);
-    goto CPyL62;
-CPyL65: ;
+    goto CPyL60;
+CPyL63: ;
     CPy_DecRef(cpy_r_r11);
     CPy_DecRef(cpy_r_r15);
-    goto CPyL62;
-CPyL66: ;
+    goto CPyL60;
+CPyL64: ;
     CPy_DecRef(cpy_r_r11);
     CPy_DecRef(cpy_r_r20);
-    goto CPyL62;
-CPyL67: ;
+    goto CPyL60;
+CPyL65: ;
     CPy_DecRef(cpy_r_r29);
-    goto CPyL62;
-CPyL68: ;
+    goto CPyL60;
+CPyL66: ;
     CPy_DecRef(cpy_r_r0);
     goto CPyL11;
+CPyL67: ;
+    CPy_DecRef(cpy_r_r0);
+    goto CPyL60;
+CPyL68: ;
+    CPy_DecRef(cpy_r_r0);
+    CPy_DecRef(cpy_r_r43);
+    CPy_DecRef(cpy_r_r44);
+    goto CPyL60;
 CPyL69: ;
     CPy_DecRef(cpy_r_r0);
-    goto CPyL14;
+    CPy_DecRef(cpy_r_r43);
+    CPy_DecRef(cpy_r_r46);
+    goto CPyL60;
 CPyL70: ;
-    CPy_DecRef(cpy_r_r0);
-    goto CPyL62;
+    CPy_DECREF(cpy_r_r51);
+    goto CPyL18;
 CPyL71: ;
     CPy_DecRef(cpy_r_r0);
-    CPy_DecRef(cpy_r_r42);
     CPy_DecRef(cpy_r_r43);
-    goto CPyL62;
+    CPy_DecRef(cpy_r_r46);
+    goto CPyL21;
 CPyL72: ;
-    CPy_DecRef(cpy_r_r0);
-    CPy_DecRef(cpy_r_r42);
-    CPy_DecRef(cpy_r_r45);
-    goto CPyL62;
-CPyL73: ;
-    CPy_DECREF(cpy_r_r50);
-    goto CPyL20;
-CPyL74: ;
-    CPy_DecRef(cpy_r_r0);
-    CPy_DecRef(cpy_r_r42);
-    CPy_DecRef(cpy_r_r45);
-    goto CPyL23;
-CPyL75: ;
-    CPy_DecRef(cpy_r_r60);
     CPy_DecRef(cpy_r_r61);
     CPy_DecRef(cpy_r_r62);
-    goto CPyL32;
+    CPy_DecRef(cpy_r_r63);
+    goto CPyL30;
+CPyL73: ;
+    CPy_DecRef(cpy_r_r0);
+    CPy_DecRef(cpy_r_r43);
+    CPy_DecRef(cpy_r_r46);
+    CPy_DecRef(cpy_r_r59.f0);
+    CPy_DecRef(cpy_r_r59.f1);
+    CPy_DecRef(cpy_r_r59.f2);
+    goto CPyL28;
+CPyL74: ;
+    CPy_DecRef(cpy_r_r0);
+    CPy_DecRef(cpy_r_r43);
+    CPy_DecRef(cpy_r_r46);
+    goto CPyL31;
+CPyL75: ;
+    CPy_DECREF(cpy_r_r43);
+    CPy_DECREF(cpy_r_r46);
+    goto CPyL37;
 CPyL76: ;
     CPy_DecRef(cpy_r_r0);
-    CPy_DecRef(cpy_r_r42);
-    CPy_DecRef(cpy_r_r45);
-    CPy_DecRef(cpy_r_r58.f0);
-    CPy_DecRef(cpy_r_r58.f1);
-    CPy_DecRef(cpy_r_r58.f2);
-    goto CPyL30;
-CPyL77: ;
-    CPy_DecRef(cpy_r_r0);
-    CPy_DecRef(cpy_r_r42);
-    CPy_DecRef(cpy_r_r45);
-    goto CPyL33;
-CPyL78: ;
-    CPy_DECREF(cpy_r_r42);
-    CPy_DECREF(cpy_r_r45);
-    goto CPyL39;
-CPyL79: ;
-    CPy_DecRef(cpy_r_r0);
-    CPy_DecRef(cpy_r_r42);
-    goto CPyL42;
-CPyL80: ;
-    CPy_DECREF(cpy_r_r76);
-    goto CPyL38;
-CPyL81: ;
-    CPy_DECREF_NO_IMM(cpy_r_r0);
+    CPy_DecRef(cpy_r_r43);
     goto CPyL40;
+CPyL77: ;
+    CPy_DECREF(cpy_r_r77);
+    goto CPyL36;
+CPyL78: ;
+    CPy_DECREF_NO_IMM(cpy_r_r0);
+    goto CPyL38;
+CPyL79: ;
+    CPy_XDECREF(cpy_r_r72.f0);
+    CPy_XDECREF(cpy_r_r72.f1);
+    CPy_XDECREF(cpy_r_r72.f2);
+    goto CPyL39;
+CPyL80: ;
+    CPy_DecRef(cpy_r_r79);
+    goto CPyL60;
+CPyL81: ;
+    CPy_DecRef(cpy_r_f);
+    goto CPyL60;
 CPyL82: ;
-    CPy_XDECREF(cpy_r_r71.f0);
-    CPy_XDECREF(cpy_r_r71.f1);
-    CPy_XDECREF(cpy_r_r71.f2);
-    goto CPyL41;
-CPyL83: ;
-    CPy_DecRef(cpy_r_r78);
-    goto CPyL62;
-CPyL84: ;
     CPy_DecRef(cpy_r_f);
-    goto CPyL62;
-CPyL85: ;
-    CPy_DecRef(cpy_r_f);
-    CPy_DecRef(cpy_r_r95);
-    goto CPyL62;
+    CPy_DecRef(cpy_r_r96);
+    goto CPyL60;
 }
 
 PyObject *CPyPy_numeric___scale_places(PyObject *self, PyObject *const *args, size_t nargs, PyObject *kwnames) {
@@ -13763,7 +13729,7 @@ PyObject *CPyPy_numeric___scale_places(PyObject *self, PyObject *const *args, si
     PyObject *retval = CPyDef_numeric___scale_places(arg_places);
     return retval;
 fail: ;
-    CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 91, CPyStatic_numeric___globals);
+    CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "scale_places", 92, CPyStatic_numeric___globals);
     return NULL;
 }
 
@@ -13805,24 +13771,24 @@ char CPyDef_numeric_____top_level__(void) {
     PyObject *cpy_r_r37;
     PyObject *cpy_r_r38;
     PyObject *cpy_r_r39;
-    PyObject *cpy_r_r40;
-    int32_t cpy_r_r41;
-    char cpy_r_r42;
+    PyObject **cpy_r_r41;
+    PyObject *cpy_r_r42;
     PyObject *cpy_r_r43;
     PyObject *cpy_r_r44;
-    PyObject *cpy_r_r45;
-    PyObject *cpy_r_r46;
-    PyObject **cpy_r_r48;
+    int32_t cpy_r_r45;
+    char cpy_r_r46;
+    PyObject *cpy_r_r47;
+    PyObject *cpy_r_r48;
     PyObject *cpy_r_r49;
     PyObject *cpy_r_r50;
-    PyObject *cpy_r_r51;
-    int32_t cpy_r_r52;
-    char cpy_r_r53;
+    PyObject **cpy_r_r52;
+    PyObject *cpy_r_r53;
     PyObject *cpy_r_r54;
     PyObject *cpy_r_r55;
-    PyObject *cpy_r_r56;
-    PyObject *cpy_r_r57;
-    PyObject **cpy_r_r59;
+    int32_t cpy_r_r56;
+    char cpy_r_r57;
+    PyObject *cpy_r_r58;
+    PyObject *cpy_r_r59;
     PyObject *cpy_r_r60;
     PyObject *cpy_r_r61;
     PyObject *cpy_r_r62;
@@ -13831,31 +13797,24 @@ char CPyDef_numeric_____top_level__(void) {
     PyObject *cpy_r_r65;
     PyObject *cpy_r_r66;
     PyObject *cpy_r_r67;
-    PyObject *cpy_r_r68;
-    PyObject *cpy_r_r69;
-    int32_t cpy_r_r70;
-    char cpy_r_r71;
+    int32_t cpy_r_r68;
+    char cpy_r_r69;
+    PyObject *cpy_r_r70;
+    PyObject *cpy_r_r71;
     PyObject *cpy_r_r72;
-    PyObject *cpy_r_r73;
-    PyObject *cpy_r_r74;
-    int32_t cpy_r_r75;
-    char cpy_r_r76;
+    int32_t cpy_r_r73;
+    char cpy_r_r74;
+    PyObject *cpy_r_r75;
+    PyObject *cpy_r_r76;
     PyObject *cpy_r_r77;
-    PyObject *cpy_r_r78;
-    PyObject *cpy_r_r79;
-    int32_t cpy_r_r80;
-    char cpy_r_r81;
+    int32_t cpy_r_r78;
+    char cpy_r_r79;
+    PyObject *cpy_r_r80;
+    PyObject *cpy_r_r81;
     PyObject *cpy_r_r82;
-    PyObject *cpy_r_r83;
-    PyObject *cpy_r_r84;
-    int32_t cpy_r_r85;
-    char cpy_r_r86;
-    PyObject *cpy_r_r87;
-    PyObject *cpy_r_r88;
-    PyObject *cpy_r_r89;
-    int32_t cpy_r_r90;
-    char cpy_r_r91;
-    char cpy_r_r92;
+    int32_t cpy_r_r83;
+    char cpy_r_r84;
+    char cpy_r_r85;
     cpy_r_r0 = CPyModule_builtins;
     cpy_r_r1 = (PyObject *)&_Py_NoneStruct;
     cpy_r_r2 = cpy_r_r0 != cpy_r_r1;
@@ -13864,7 +13823,7 @@ char CPyDef_numeric_____top_level__(void) {
     cpy_r_r4 = PyImport_Import(cpy_r_r3);
     if (unlikely(cpy_r_r4 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", -1, CPyStatic_numeric___globals);
-        goto CPyL28;
+        goto CPyL26;
     }
     CPyModule_builtins = cpy_r_r4;
     CPy_INCREF(CPyModule_builtins);
@@ -13875,218 +13834,200 @@ CPyL3: ;
     cpy_r_r7 = (void *)&cpy_r_r6;
     int64_t cpy_r_r8[1] = {1};
     cpy_r_r9 = (void *)&cpy_r_r8;
-    cpy_r_r10 = CPyStatics[268]; /* (('decimal', 'decimal', 'decimal'),) */
+    cpy_r_r10 = CPyStatics[267]; /* (('decimal', 'decimal', 'decimal'),) */
     cpy_r_r11 = CPyStatic_numeric___globals;
-    cpy_r_r12 = CPyStatics[198]; /* 'faster_eth_abi/utils/numeric.py' */
+    cpy_r_r12 = CPyStatics[199]; /* 'faster_eth_abi/utils/numeric.py' */
     cpy_r_r13 = CPyStatics[103]; /* '<module>' */
     cpy_r_r14 = CPyImport_ImportMany(cpy_r_r10, cpy_r_r7, cpy_r_r11, cpy_r_r12, cpy_r_r13, cpy_r_r9);
-    if (!cpy_r_r14) goto CPyL28;
-    cpy_r_r15 = CPyStatics[269]; /* ('Callable', 'Dict', 'Final', 'Tuple') */
+    if (!cpy_r_r14) goto CPyL26;
+    cpy_r_r15 = CPyStatics[268]; /* ('Callable', 'Dict', 'Final', 'Tuple') */
     cpy_r_r16 = CPyStatics[16]; /* 'typing' */
     cpy_r_r17 = CPyStatic_numeric___globals;
     cpy_r_r18 = CPyImport_ImportFromMany(cpy_r_r16, cpy_r_r15, cpy_r_r15, cpy_r_r17);
     if (unlikely(cpy_r_r18 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 2, CPyStatic_numeric___globals);
-        goto CPyL28;
+        goto CPyL26;
     }
     CPyModule_typing = cpy_r_r18;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r18);
     cpy_r_r19 = CPyStatic_numeric___globals;
-    cpy_r_r20 = CPyStatics[200]; /* 'ABI_DECIMAL_PREC' */
-    cpy_r_r21 = CPyStatics[234]; /* 999 */
+    cpy_r_r20 = CPyStatics[201]; /* 'ABI_DECIMAL_PREC' */
+    cpy_r_r21 = CPyStatics[233]; /* 999 */
     cpy_r_r22 = CPyDict_SetItem(cpy_r_r19, cpy_r_r20, cpy_r_r21);
     cpy_r_r23 = cpy_r_r22 >= 0;
     if (unlikely(!cpy_r_r23)) {
         CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 9, CPyStatic_numeric___globals);
-        goto CPyL28;
+        goto CPyL26;
     }
     cpy_r_r24 = CPyModule_decimal;
-    cpy_r_r25 = CPyStatics[201]; /* 'Context' */
+    cpy_r_r25 = CPyStatics[202]; /* 'Context' */
     cpy_r_r26 = CPyObject_GetAttr(cpy_r_r24, cpy_r_r25);
     if (unlikely(cpy_r_r26 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 11, CPyStatic_numeric___globals);
-        goto CPyL28;
+        goto CPyL26;
     }
-    cpy_r_r27 = CPyStatics[234]; /* 999 */
+    cpy_r_r27 = CPyStatics[233]; /* 999 */
     PyObject *cpy_r_r28[1] = {cpy_r_r27};
     cpy_r_r29 = (PyObject **)&cpy_r_r28;
-    cpy_r_r30 = CPyStatics[270]; /* ('prec',) */
+    cpy_r_r30 = CPyStatics[269]; /* ('prec',) */
     cpy_r_r31 = PyObject_Vectorcall(cpy_r_r26, cpy_r_r29, 0, cpy_r_r30);
     CPy_DECREF(cpy_r_r26);
     if (unlikely(cpy_r_r31 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 11, CPyStatic_numeric___globals);
-        goto CPyL28;
+        goto CPyL26;
     }
     CPyStatic_numeric___abi_decimal_context = cpy_r_r31;
     CPy_INCREF(CPyStatic_numeric___abi_decimal_context);
     cpy_r_r32 = CPyStatic_numeric___globals;
-    cpy_r_r33 = CPyStatics[203]; /* 'abi_decimal_context' */
+    cpy_r_r33 = CPyStatics[204]; /* 'abi_decimal_context' */
     cpy_r_r34 = CPyDict_SetItem(cpy_r_r32, cpy_r_r33, cpy_r_r31);
     CPy_DECREF(cpy_r_r31);
     cpy_r_r35 = cpy_r_r34 >= 0;
     if (unlikely(!cpy_r_r35)) {
         CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 11, CPyStatic_numeric___globals);
-        goto CPyL28;
+        goto CPyL26;
     }
     cpy_r_r36 = CPyModule_decimal;
-    cpy_r_r37 = CPyStatics[204]; /* 'localcontext' */
+    cpy_r_r37 = CPyStatics[205]; /* 'Decimal' */
     cpy_r_r38 = CPyObject_GetAttr(cpy_r_r36, cpy_r_r37);
     if (unlikely(cpy_r_r38 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 12, CPyStatic_numeric___globals);
-        goto CPyL28;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 13, CPyStatic_numeric___globals);
+        goto CPyL26;
     }
-    CPyStatic_numeric___decimal_localcontext = cpy_r_r38;
-    CPy_INCREF(CPyStatic_numeric___decimal_localcontext);
-    cpy_r_r39 = CPyStatic_numeric___globals;
-    cpy_r_r40 = CPyStatics[205]; /* 'decimal_localcontext' */
-    cpy_r_r41 = CPyDict_SetItem(cpy_r_r39, cpy_r_r40, cpy_r_r38);
+    cpy_r_r39 = CPyStatics[224]; /* 0 */
+    PyObject *cpy_r_r40[1] = {cpy_r_r39};
+    cpy_r_r41 = (PyObject **)&cpy_r_r40;
+    cpy_r_r42 = PyObject_Vectorcall(cpy_r_r38, cpy_r_r41, 1, 0);
     CPy_DECREF(cpy_r_r38);
-    cpy_r_r42 = cpy_r_r41 >= 0;
-    if (unlikely(!cpy_r_r42)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 12, CPyStatic_numeric___globals);
-        goto CPyL28;
+    if (unlikely(cpy_r_r42 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 13, CPyStatic_numeric___globals);
+        goto CPyL26;
     }
-    cpy_r_r43 = CPyModule_decimal;
-    cpy_r_r44 = CPyStatics[206]; /* 'Decimal' */
-    cpy_r_r45 = CPyObject_GetAttr(cpy_r_r43, cpy_r_r44);
-    if (unlikely(cpy_r_r45 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 14, CPyStatic_numeric___globals);
-        goto CPyL28;
+    CPyStatic_numeric___ZERO = cpy_r_r42;
+    CPy_INCREF(CPyStatic_numeric___ZERO);
+    cpy_r_r43 = CPyStatic_numeric___globals;
+    cpy_r_r44 = CPyStatics[206]; /* 'ZERO' */
+    cpy_r_r45 = CPyDict_SetItem(cpy_r_r43, cpy_r_r44, cpy_r_r42);
+    CPy_DECREF(cpy_r_r42);
+    cpy_r_r46 = cpy_r_r45 >= 0;
+    if (unlikely(!cpy_r_r46)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 13, CPyStatic_numeric___globals);
+        goto CPyL26;
     }
-    cpy_r_r46 = CPyStatics[225]; /* 0 */
-    PyObject *cpy_r_r47[1] = {cpy_r_r46};
-    cpy_r_r48 = (PyObject **)&cpy_r_r47;
-    cpy_r_r49 = PyObject_Vectorcall(cpy_r_r45, cpy_r_r48, 1, 0);
-    CPy_DECREF(cpy_r_r45);
+    cpy_r_r47 = CPyModule_decimal;
+    cpy_r_r48 = CPyStatics[205]; /* 'Decimal' */
+    cpy_r_r49 = CPyObject_GetAttr(cpy_r_r47, cpy_r_r48);
     if (unlikely(cpy_r_r49 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 14, CPyStatic_numeric___globals);
-        goto CPyL28;
+        goto CPyL26;
     }
-    CPyStatic_numeric___ZERO = cpy_r_r49;
-    CPy_INCREF(CPyStatic_numeric___ZERO);
-    cpy_r_r50 = CPyStatic_numeric___globals;
-    cpy_r_r51 = CPyStatics[207]; /* 'ZERO' */
-    cpy_r_r52 = CPyDict_SetItem(cpy_r_r50, cpy_r_r51, cpy_r_r49);
+    cpy_r_r50 = CPyStatics[234]; /* 10 */
+    PyObject *cpy_r_r51[1] = {cpy_r_r50};
+    cpy_r_r52 = (PyObject **)&cpy_r_r51;
+    cpy_r_r53 = PyObject_Vectorcall(cpy_r_r49, cpy_r_r52, 1, 0);
     CPy_DECREF(cpy_r_r49);
-    cpy_r_r53 = cpy_r_r52 >= 0;
-    if (unlikely(!cpy_r_r53)) {
+    if (unlikely(cpy_r_r53 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 14, CPyStatic_numeric___globals);
-        goto CPyL28;
+        goto CPyL26;
     }
-    cpy_r_r54 = CPyModule_decimal;
-    cpy_r_r55 = CPyStatics[206]; /* 'Decimal' */
-    cpy_r_r56 = CPyObject_GetAttr(cpy_r_r54, cpy_r_r55);
-    if (unlikely(cpy_r_r56 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 15, CPyStatic_numeric___globals);
-        goto CPyL28;
-    }
-    cpy_r_r57 = CPyStatics[235]; /* 10 */
-    PyObject *cpy_r_r58[1] = {cpy_r_r57};
-    cpy_r_r59 = (PyObject **)&cpy_r_r58;
-    cpy_r_r60 = PyObject_Vectorcall(cpy_r_r56, cpy_r_r59, 1, 0);
-    CPy_DECREF(cpy_r_r56);
-    if (unlikely(cpy_r_r60 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 15, CPyStatic_numeric___globals);
-        goto CPyL28;
-    }
-    CPyStatic_numeric___TEN = cpy_r_r60;
+    CPyStatic_numeric___TEN = cpy_r_r53;
     CPy_INCREF(CPyStatic_numeric___TEN);
+    cpy_r_r54 = CPyStatic_numeric___globals;
+    cpy_r_r55 = CPyStatics[207]; /* 'TEN' */
+    cpy_r_r56 = CPyDict_SetItem(cpy_r_r54, cpy_r_r55, cpy_r_r53);
+    CPy_DECREF(cpy_r_r53);
+    cpy_r_r57 = cpy_r_r56 >= 0;
+    if (unlikely(!cpy_r_r57)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 14, CPyStatic_numeric___globals);
+        goto CPyL26;
+    }
+    cpy_r_r58 = CPyModule_decimal;
+    cpy_r_r59 = CPyStatics[205]; /* 'Decimal' */
+    cpy_r_r60 = CPyObject_GetAttr(cpy_r_r58, cpy_r_r59);
+    if (unlikely(cpy_r_r60 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 16, CPyStatic_numeric___globals);
+        goto CPyL26;
+    }
+    CPyStatic_numeric___Decimal = cpy_r_r60;
+    CPy_INCREF(CPyStatic_numeric___Decimal);
     cpy_r_r61 = CPyStatic_numeric___globals;
-    cpy_r_r62 = CPyStatics[208]; /* 'TEN' */
+    cpy_r_r62 = CPyStatics[205]; /* 'Decimal' */
     cpy_r_r63 = CPyDict_SetItem(cpy_r_r61, cpy_r_r62, cpy_r_r60);
     CPy_DECREF(cpy_r_r60);
     cpy_r_r64 = cpy_r_r63 >= 0;
     if (unlikely(!cpy_r_r64)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 15, CPyStatic_numeric___globals);
-        goto CPyL28;
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 16, CPyStatic_numeric___globals);
+        goto CPyL26;
     }
-    cpy_r_r65 = CPyModule_decimal;
-    cpy_r_r66 = CPyStatics[206]; /* 'Decimal' */
-    cpy_r_r67 = CPyObject_GetAttr(cpy_r_r65, cpy_r_r66);
-    if (unlikely(cpy_r_r67 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 17, CPyStatic_numeric___globals);
-        goto CPyL28;
+    cpy_r_r65 = PyDict_New();
+    if (unlikely(cpy_r_r65 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 24, CPyStatic_numeric___globals);
+        goto CPyL26;
     }
-    CPyStatic_numeric___Decimal = cpy_r_r67;
-    CPy_INCREF(CPyStatic_numeric___Decimal);
-    cpy_r_r68 = CPyStatic_numeric___globals;
-    cpy_r_r69 = CPyStatics[206]; /* 'Decimal' */
-    cpy_r_r70 = CPyDict_SetItem(cpy_r_r68, cpy_r_r69, cpy_r_r67);
-    CPy_DECREF(cpy_r_r67);
-    cpy_r_r71 = cpy_r_r70 >= 0;
-    if (unlikely(!cpy_r_r71)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 17, CPyStatic_numeric___globals);
-        goto CPyL28;
-    }
-    cpy_r_r72 = PyDict_New();
-    if (unlikely(cpy_r_r72 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 25, CPyStatic_numeric___globals);
-        goto CPyL28;
-    }
-    CPyStatic_numeric____unsigned_integer_bounds_cache = cpy_r_r72;
+    CPyStatic_numeric____unsigned_integer_bounds_cache = cpy_r_r65;
     CPy_INCREF(CPyStatic_numeric____unsigned_integer_bounds_cache);
-    cpy_r_r73 = CPyStatic_numeric___globals;
-    cpy_r_r74 = CPyStatics[209]; /* '_unsigned_integer_bounds_cache' */
-    cpy_r_r75 = CPyDict_SetItem(cpy_r_r73, cpy_r_r74, cpy_r_r72);
-    CPy_DECREF(cpy_r_r72);
-    cpy_r_r76 = cpy_r_r75 >= 0;
-    if (unlikely(!cpy_r_r76)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 25, CPyStatic_numeric___globals);
-        goto CPyL28;
+    cpy_r_r66 = CPyStatic_numeric___globals;
+    cpy_r_r67 = CPyStatics[208]; /* '_unsigned_integer_bounds_cache' */
+    cpy_r_r68 = CPyDict_SetItem(cpy_r_r66, cpy_r_r67, cpy_r_r65);
+    CPy_DECREF(cpy_r_r65);
+    cpy_r_r69 = cpy_r_r68 >= 0;
+    if (unlikely(!cpy_r_r69)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 24, CPyStatic_numeric___globals);
+        goto CPyL26;
     }
-    cpy_r_r77 = PyDict_New();
-    if (unlikely(cpy_r_r77 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 36, CPyStatic_numeric___globals);
-        goto CPyL28;
+    cpy_r_r70 = PyDict_New();
+    if (unlikely(cpy_r_r70 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 35, CPyStatic_numeric___globals);
+        goto CPyL26;
     }
-    CPyStatic_numeric____signed_integer_bounds_cache = cpy_r_r77;
+    CPyStatic_numeric____signed_integer_bounds_cache = cpy_r_r70;
     CPy_INCREF(CPyStatic_numeric____signed_integer_bounds_cache);
-    cpy_r_r78 = CPyStatic_numeric___globals;
-    cpy_r_r79 = CPyStatics[210]; /* '_signed_integer_bounds_cache' */
-    cpy_r_r80 = CPyDict_SetItem(cpy_r_r78, cpy_r_r79, cpy_r_r77);
-    CPy_DECREF(cpy_r_r77);
-    cpy_r_r81 = cpy_r_r80 >= 0;
-    if (unlikely(!cpy_r_r81)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 36, CPyStatic_numeric___globals);
-        goto CPyL28;
+    cpy_r_r71 = CPyStatic_numeric___globals;
+    cpy_r_r72 = CPyStatics[209]; /* '_signed_integer_bounds_cache' */
+    cpy_r_r73 = CPyDict_SetItem(cpy_r_r71, cpy_r_r72, cpy_r_r70);
+    CPy_DECREF(cpy_r_r70);
+    cpy_r_r74 = cpy_r_r73 >= 0;
+    if (unlikely(!cpy_r_r74)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 35, CPyStatic_numeric___globals);
+        goto CPyL26;
     }
-    cpy_r_r82 = PyDict_New();
-    if (unlikely(cpy_r_r82 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 50, CPyStatic_numeric___globals);
-        goto CPyL28;
+    cpy_r_r75 = PyDict_New();
+    if (unlikely(cpy_r_r75 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 49, CPyStatic_numeric___globals);
+        goto CPyL26;
     }
-    CPyStatic_numeric____unsigned_fixed_bounds_cache = cpy_r_r82;
+    CPyStatic_numeric____unsigned_fixed_bounds_cache = cpy_r_r75;
     CPy_INCREF(CPyStatic_numeric____unsigned_fixed_bounds_cache);
-    cpy_r_r83 = CPyStatic_numeric___globals;
-    cpy_r_r84 = CPyStatics[211]; /* '_unsigned_fixed_bounds_cache' */
-    cpy_r_r85 = CPyDict_SetItem(cpy_r_r83, cpy_r_r84, cpy_r_r82);
-    CPy_DECREF(cpy_r_r82);
-    cpy_r_r86 = cpy_r_r85 >= 0;
-    if (unlikely(!cpy_r_r86)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 50, CPyStatic_numeric___globals);
-        goto CPyL28;
+    cpy_r_r76 = CPyStatic_numeric___globals;
+    cpy_r_r77 = CPyStatics[210]; /* '_unsigned_fixed_bounds_cache' */
+    cpy_r_r78 = CPyDict_SetItem(cpy_r_r76, cpy_r_r77, cpy_r_r75);
+    CPy_DECREF(cpy_r_r75);
+    cpy_r_r79 = cpy_r_r78 >= 0;
+    if (unlikely(!cpy_r_r79)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 49, CPyStatic_numeric___globals);
+        goto CPyL26;
     }
-    cpy_r_r87 = PyDict_New();
-    if (unlikely(cpy_r_r87 == NULL)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 69, CPyStatic_numeric___globals);
-        goto CPyL28;
+    cpy_r_r80 = PyDict_New();
+    if (unlikely(cpy_r_r80 == NULL)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 70, CPyStatic_numeric___globals);
+        goto CPyL26;
     }
-    CPyStatic_numeric____signed_fixed_bounds_cache = cpy_r_r87;
+    CPyStatic_numeric____signed_fixed_bounds_cache = cpy_r_r80;
     CPy_INCREF(CPyStatic_numeric____signed_fixed_bounds_cache);
-    cpy_r_r88 = CPyStatic_numeric___globals;
-    cpy_r_r89 = CPyStatics[212]; /* '_signed_fixed_bounds_cache' */
-    cpy_r_r90 = CPyDict_SetItem(cpy_r_r88, cpy_r_r89, cpy_r_r87);
-    CPy_DECREF(cpy_r_r87);
-    cpy_r_r91 = cpy_r_r90 >= 0;
-    if (unlikely(!cpy_r_r91)) {
-        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 69, CPyStatic_numeric___globals);
-        goto CPyL28;
+    cpy_r_r81 = CPyStatic_numeric___globals;
+    cpy_r_r82 = CPyStatics[211]; /* '_signed_fixed_bounds_cache' */
+    cpy_r_r83 = CPyDict_SetItem(cpy_r_r81, cpy_r_r82, cpy_r_r80);
+    CPy_DECREF(cpy_r_r80);
+    cpy_r_r84 = cpy_r_r83 >= 0;
+    if (unlikely(!cpy_r_r84)) {
+        CPy_AddTraceback("faster_eth_abi/utils/numeric.py", "<module>", 70, CPyStatic_numeric___globals);
+        goto CPyL26;
     }
     return 1;
-CPyL28: ;
-    cpy_r_r92 = 2;
-    return cpy_r_r92;
+CPyL26: ;
+    cpy_r_r85 = 2;
+    return cpy_r_r85;
 }
 static PyMethodDef paddingmodule_methods[] = {
     {"zpad", (PyCFunction)CPyPy_padding___zpad, METH_FASTCALL | METH_KEYWORDS, PyDoc_STR("zpad(value, length)\n--\n\n") /* docstring */},
@@ -14150,7 +14091,7 @@ PyObject *CPyDef_padding___zpad(PyObject *cpy_r_value, CPyTagged cpy_r_length) {
     PyObject *cpy_r_r5;
     PyObject *cpy_r_r6;
     PyObject *cpy_r_r7;
-    cpy_r_r0 = CPyStatics[221]; /* b'\x00' */
+    cpy_r_r0 = CPyStatics[220]; /* b'\x00' */
     cpy_r_r1 = CPyStatics[55]; /* 'rjust' */
     CPyTagged_INCREF(cpy_r_length);
     cpy_r_r2 = CPyTagged_StealAsObject(cpy_r_length);
@@ -14248,7 +14189,7 @@ PyObject *CPyDef_padding___zpad_right(PyObject *cpy_r_value, CPyTagged cpy_r_len
     PyObject *cpy_r_r5;
     PyObject *cpy_r_r6;
     PyObject *cpy_r_r7;
-    cpy_r_r0 = CPyStatics[221]; /* b'\x00' */
+    cpy_r_r0 = CPyStatics[220]; /* b'\x00' */
     cpy_r_r1 = CPyStatics[56]; /* 'ljust' */
     CPyTagged_INCREF(cpy_r_length);
     cpy_r_r2 = CPyTagged_StealAsObject(cpy_r_length);
@@ -14346,7 +14287,7 @@ PyObject *CPyDef_padding___fpad(PyObject *cpy_r_value, CPyTagged cpy_r_length) {
     PyObject *cpy_r_r5;
     PyObject *cpy_r_r6;
     PyObject *cpy_r_r7;
-    cpy_r_r0 = CPyStatics[223]; /* b'\xff' */
+    cpy_r_r0 = CPyStatics[222]; /* b'\xff' */
     cpy_r_r1 = CPyStatics[55]; /* 'rjust' */
     CPyTagged_INCREF(cpy_r_length);
     cpy_r_r2 = CPyTagged_StealAsObject(cpy_r_length);
@@ -14592,7 +14533,7 @@ CPyL11: ;
     } else
         goto CPyL16;
 CPyL12: ;
-    cpy_r_r16 = CPyStatics[213]; /* 'Abbreviation limit may not be less than 3' */
+    cpy_r_r16 = CPyStatics[212]; /* 'Abbreviation limit may not be less than 3' */
     cpy_r_r17 = CPyModule_builtins;
     cpy_r_r18 = CPyStatics[87]; /* 'ValueError' */
     cpy_r_r19 = CPyObject_GetAttr(cpy_r_r17, cpy_r_r18);
@@ -14631,7 +14572,7 @@ CPyL16: ;
         CPy_TypeErrorTraceback("faster_eth_abi/utils/string.py", "abbr", 17, CPyStatic_string___globals, "str", cpy_r_r24);
         goto CPyL21;
     }
-    cpy_r_r26 = CPyStatics[214]; /* '...' */
+    cpy_r_r26 = CPyStatics[213]; /* '...' */
     cpy_r_r27 = PyUnicode_Concat(cpy_r_r25, cpy_r_r26);
     CPy_DECREF(cpy_r_r25);
     if (unlikely(cpy_r_r27 == NULL)) {
@@ -14712,7 +14653,7 @@ char CPyDef_string_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[271]; /* ('Any',) */
+    cpy_r_r5 = CPyStatics[270]; /* ('Any',) */
     cpy_r_r6 = CPyStatics[16]; /* 'typing' */
     cpy_r_r7 = CPyStatic_string___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
@@ -14801,7 +14742,7 @@ char CPyDef_validation___validate_bytes_param(PyObject *cpy_r_param, PyObject *c
     char cpy_r_r20;
     cpy_r_r0 = (PyObject *)&PyBytes_Type;
     cpy_r_r1 = CPyModule_builtins;
-    cpy_r_r2 = CPyStatics[215]; /* 'bytearray' */
+    cpy_r_r2 = CPyStatics[214]; /* 'bytearray' */
     cpy_r_r3 = CPyObject_GetAttr(cpy_r_r1, cpy_r_r2);
     if (unlikely(cpy_r_r3 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/utils/validation.py", "validate_bytes_param", 7, CPyStatic_validation___globals);
@@ -14826,8 +14767,8 @@ char CPyDef_validation___validate_bytes_param(PyObject *cpy_r_param, PyObject *c
     }
     cpy_r_r8 = cpy_r_r6;
     if (cpy_r_r8) goto CPyL9;
-    cpy_r_r9 = CPyStatics[216]; /* 'The `' */
-    cpy_r_r10 = CPyStatics[217]; /* '` value must be of bytes type. Got ' */
+    cpy_r_r9 = CPyStatics[215]; /* 'The `' */
+    cpy_r_r10 = CPyStatics[216]; /* '` value must be of bytes type. Got ' */
     cpy_r_r11 = CPy_TYPE(cpy_r_param);
     cpy_r_r12 = PyObject_Str(cpy_r_r11);
     CPy_DECREF(cpy_r_r11);
@@ -14842,7 +14783,7 @@ char CPyDef_validation___validate_bytes_param(PyObject *cpy_r_param, PyObject *c
         goto CPyL10;
     }
     cpy_r_r14 = CPyModule_builtins;
-    cpy_r_r15 = CPyStatics[218]; /* 'TypeError' */
+    cpy_r_r15 = CPyStatics[217]; /* 'TypeError' */
     cpy_r_r16 = CPyObject_GetAttr(cpy_r_r14, cpy_r_r15);
     if (unlikely(cpy_r_r16 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/utils/validation.py", "validate_bytes_param", 8, CPyStatic_validation___globals);
@@ -14943,8 +14884,8 @@ char CPyDef_validation___validate_list_like_param(PyObject *cpy_r_param, PyObjec
     }
     cpy_r_r6 = cpy_r_r4;
     if (cpy_r_r6) goto CPyL8;
-    cpy_r_r7 = CPyStatics[216]; /* 'The `' */
-    cpy_r_r8 = CPyStatics[219]; /* '` value type must be one of list or tuple. Got ' */
+    cpy_r_r7 = CPyStatics[215]; /* 'The `' */
+    cpy_r_r8 = CPyStatics[218]; /* '` value type must be one of list or tuple. Got ' */
     cpy_r_r9 = CPy_TYPE(cpy_r_param);
     cpy_r_r10 = PyObject_Str(cpy_r_r9);
     CPy_DECREF(cpy_r_r9);
@@ -14959,7 +14900,7 @@ char CPyDef_validation___validate_list_like_param(PyObject *cpy_r_param, PyObjec
         goto CPyL9;
     }
     cpy_r_r12 = CPyModule_builtins;
-    cpy_r_r13 = CPyStatics[218]; /* 'TypeError' */
+    cpy_r_r13 = CPyStatics[217]; /* 'TypeError' */
     cpy_r_r14 = CPyObject_GetAttr(cpy_r_r12, cpy_r_r13);
     if (unlikely(cpy_r_r14 == NULL)) {
         CPy_AddTraceback("faster_eth_abi/utils/validation.py", "validate_list_like_param", 15, CPyStatic_validation___globals);
@@ -15044,7 +14985,7 @@ char CPyDef_validation_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[271]; /* ('Any',) */
+    cpy_r_r5 = CPyStatics[270]; /* ('Any',) */
     cpy_r_r6 = CPyStatics[16]; /* 'typing' */
     cpy_r_r7 = CPyStatic_validation___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
@@ -15133,7 +15074,7 @@ int CPyGlobalsInit(void)
     return 0;
 }
 
-PyObject *CPyStatics[272];
+PyObject *CPyStatics[271];
 const char * const CPyLit_Str[] = {
     "\a\005types\004args\t_registry\021get_tuple_encoder\004data\021get_tuple_decoder\006strict",
     "\a\fstream_class\bbuiltins\rTYPE_CHECKING\003Any\bIterable\005Tuple\006typing",
@@ -15173,15 +15114,15 @@ const char * const CPyLit_Str[] = {
     "\005\017string_strategy\021strategy_registry\004uint\021get_uint_strategy\003int",
     "\006\020get_int_strategy\aaddress\bwith_sub\004bool\006ufixed\023get_ufixed_strategy",
     "\006\005fixed\022get_fixed_strategy\005bytes\022get_bytes_strategy\bbytes<M>\bfunction",
-    "\005\006string\022get_array_strategy\022get_tuple_strategy\fget_strategy\b__exit__",
-    "\005\t__enter__*Argument `places` must be int.  Got value \t of type \001.\004Eneg",
-    "\005\004Epos\tscale_by_\b__name__\f__qualname__\adecimal",
+    "\004\006string\022get_array_strategy\022get_tuple_strategy\fget_strategy",
+    "\003\flocalcontext\b__exit__\t__enter__",
+    "\005*Argument `places` must be int.  Got value \t of type \001.\004Eneg\004Epos",
+    "\004\tscale_by_\b__name__\f__qualname__\adecimal",
     "\005\037faster_eth_abi/utils/numeric.py\004Dict\020ABI_DECIMAL_PREC\aContext\004prec",
-    "\005\023abi_decimal_context\flocalcontext\024decimal_localcontext\aDecimal\004ZERO",
-    "\003\003TEN\036_unsigned_integer_bounds_cache\034_signed_integer_bounds_cache",
-    "\002\034_unsigned_fixed_bounds_cache\032_signed_fixed_bounds_cache",
-    "\004)Abbreviation limit may not be less than 3\003...\tbytearray\005The `",
-    "\002#` value must be of bytes type. Got \tTypeError",
+    "\005\023abi_decimal_context\aDecimal\004ZERO\003TEN\036_unsigned_integer_bounds_cache",
+    "\002\034_signed_integer_bounds_cache\034_unsigned_fixed_bounds_cache",
+    "\002\032_signed_fixed_bounds_cache)Abbreviation limit may not be less than 3",
+    "\005\003...\tbytearray\005The `#` value must be of bytes type. Got \tTypeError",
     "\001/` value type must be one of list or tuple. Got ",
     "",
 };
@@ -15202,11 +15143,11 @@ const double CPyLit_Complex[] = {0};
 const int CPyLit_Tuple[] = {
     36, 4, 12, 13, 14, 15, 2, 17, 18, 2, 20, 21, 3, 12, 13, 15, 1, 24,
     2, 27, 47, 2, 51, 52, 7, 12, 13, 60, 61, 62, 63, 64, 1, 66, 1, 67, 1,
-    69, 3, 101, 101, 101, 1, 247, 6, 12, 13, 60, 62, 104, 64, 1, 18, 5,
+    69, 3, 101, 101, 101, 1, 246, 6, 12, 13, 60, 62, 104, 64, 1, 18, 5,
     105, 84, 99, 79, 80, 1, 109, 1, 112, 1, 113, 1, 117, 1, 122, 2, 129,
     130, 3, 129, 130, 132, 2, 135, 136, 4, 60, 66, 62, 142, 1, 143, 1,
-    146, 1, 125, 6, 148, 149, 150, 120, 151, 152, 1, 153, 1, 173, 3, 197,
-    197, 197, 1, 267, 4, 60, 199, 66, 15, 1, 202, 1, 13
+    146, 1, 125, 6, 148, 149, 150, 120, 151, 152, 1, 153, 1, 173, 3, 198,
+    198, 198, 1, 266, 4, 60, 200, 66, 15, 1, 203, 1, 13
 };
 const int CPyLit_FrozenSet[] = {0};
 CPyModule *CPyModule_faster_eth_abi____codec__internal = NULL;
@@ -15386,7 +15327,6 @@ PyObject *CPyPy__strategies___get_tuple_strategy(PyObject *self, PyObject *const
 char CPyDef__strategies_____top_level__(void);
 char CPyDef_utils_____top_level__(void);
 PyObject *CPyStatic_numeric___abi_decimal_context = NULL;
-PyObject *CPyStatic_numeric___decimal_localcontext = NULL;
 PyObject *CPyStatic_numeric___ZERO = NULL;
 PyObject *CPyStatic_numeric___TEN = NULL;
 PyObject *CPyStatic_numeric___Decimal = NULL;

--- a/build/__native_internal_76f9a3652d4d2667c55c.h
+++ b/build/__native_internal_76f9a3652d4d2667c55c.h
@@ -6,7 +6,7 @@
 
 int CPyGlobalsInit(void);
 
-extern PyObject *CPyStatics[272];
+extern PyObject *CPyStatics[271];
 extern const char * const CPyLit_Str[];
 extern const char * const CPyLit_Bytes[];
 extern const char * const CPyLit_Int[];
@@ -191,7 +191,6 @@ extern PyObject *CPyPy__strategies___get_tuple_strategy(PyObject *self, PyObject
 extern char CPyDef__strategies_____top_level__(void);
 extern char CPyDef_utils_____top_level__(void);
 extern PyObject *CPyStatic_numeric___abi_decimal_context;
-extern PyObject *CPyStatic_numeric___decimal_localcontext;
 extern PyObject *CPyStatic_numeric___ZERO;
 extern PyObject *CPyStatic_numeric___TEN;
 extern PyObject *CPyStatic_numeric___Decimal;

--- a/build/ops.txt
+++ b/build/ops.txt
@@ -2018,2572 +2018,6 @@ L166:
     dec_ref r317
     goto L142
 
-def __top_level__():
-    r0, r1 :: object
-    r2 :: bit
-    r3 :: str
-    r4, r5 :: object
-    r6 :: str
-    r7 :: dict
-    r8, r9 :: object
-    r10 :: str
-    r11 :: dict
-    r12, r13 :: object
-    r14 :: str
-    r15 :: dict
-    r16 :: object
-    r17 :: dict
-    r18 :: str
-    r19 :: object
-    r20 :: dict
-    r21 :: str
-    r22 :: object
-    r23 :: object[1]
-    r24 :: object_ptr
-    r25 :: object
-    r26 :: dict
-    r27 :: str
-    r28 :: i32
-    r29 :: bit
-    r30 :: object
-    r31 :: bool
-    r32 :: str
-    r33 :: object
-    r34 :: dict
-    r35 :: str
-    r36 :: i32
-    r37 :: bit
-    r38 :: object
-    r39 :: bool
-    r40 :: str
-    r41 :: object
-    r42 :: dict
-    r43 :: str
-    r44 :: i32
-    r45 :: bit
-    r46 :: None
-L0:
-    r0 = builtins :: module
-    r1 = load_address _Py_NoneStruct
-    r2 = r0 != r1
-    if r2 goto L3 else goto L1 :: bool
-L1:
-    r3 = 'builtins'
-    r4 = PyImport_Import(r3)
-    if is_error(r4) goto L21 (error at <module>:-1) else goto L2
-L2:
-    builtins = r4 :: module
-    dec_ref r4
-L3:
-    r5 = ('Final',)
-    r6 = 'typing'
-    r7 = faster_eth_abi.packed.globals :: static
-    r8 = CPyImport_ImportFromMany(r6, r5, r5, r7)
-    if is_error(r8) goto L21 (error at <module>:1) else goto L4
-L4:
-    typing = r8 :: module
-    dec_ref r8
-    r9 = ('ABIEncoder',)
-    r10 = 'faster_eth_abi.codec'
-    r11 = faster_eth_abi.packed.globals :: static
-    r12 = CPyImport_ImportFromMany(r10, r9, r9, r11)
-    if is_error(r12) goto L21 (error at <module>:5) else goto L5
-L5:
-    faster_eth_abi.codec = r12 :: module
-    dec_ref r12
-    r13 = ('registry_packed',)
-    r14 = 'faster_eth_abi.registry'
-    r15 = faster_eth_abi.packed.globals :: static
-    r16 = CPyImport_ImportFromMany(r14, r13, r13, r15)
-    if is_error(r16) goto L21 (error at <module>:8) else goto L6
-L6:
-    faster_eth_abi.registry = r16 :: module
-    dec_ref r16
-    r17 = faster_eth_abi.packed.globals :: static
-    r18 = 'registry_packed'
-    r19 = CPyDict_GetItem(r17, r18)
-    if is_error(r19) goto L21 (error at <module>:12) else goto L7
-L7:
-    r20 = faster_eth_abi.packed.globals :: static
-    r21 = 'ABIEncoder'
-    r22 = CPyDict_GetItem(r20, r21)
-    if is_error(r22) goto L22 (error at <module>:12) else goto L8
-L8:
-    r23 = [r19]
-    r24 = load_address r23
-    r25 = PyObject_Vectorcall(r22, r24, 1, 0)
-    dec_ref r22
-    if is_error(r25) goto L22 (error at <module>:12) else goto L9
-L9:
-    dec_ref r19
-    faster_eth_abi.packed.default_encoder_packed = r25 :: static
-    r26 = faster_eth_abi.packed.globals :: static
-    r27 = 'default_encoder_packed'
-    r28 = CPyDict_SetItem(r26, r27, r25)
-    dec_ref r25
-    r29 = r28 >= 0 :: signed
-    if not r29 goto L21 (error at <module>:12) else goto L10 :: bool
-L10:
-    r30 = faster_eth_abi.packed.default_encoder_packed :: static
-    if is_error(r30) goto L11 else goto L13
-L11:
-    r31 = raise NameError('value for final name "default_encoder_packed" was not set')
-    if not r31 goto L21 (error at <module>:14) else goto L12 :: bool
-L12:
-    unreachable
-L13:
-    r32 = 'encode'
-    r33 = CPyObject_GetAttr(r30, r32)
-    if is_error(r33) goto L21 (error at <module>:14) else goto L14
-L14:
-    faster_eth_abi.packed.encode_packed = r33 :: static
-    r34 = faster_eth_abi.packed.globals :: static
-    r35 = 'encode_packed'
-    r36 = CPyDict_SetItem(r34, r35, r33)
-    dec_ref r33
-    r37 = r36 >= 0 :: signed
-    if not r37 goto L21 (error at <module>:14) else goto L15 :: bool
-L15:
-    r38 = faster_eth_abi.packed.default_encoder_packed :: static
-    if is_error(r38) goto L16 else goto L18
-L16:
-    r39 = raise NameError('value for final name "default_encoder_packed" was not set')
-    if not r39 goto L21 (error at <module>:15) else goto L17 :: bool
-L17:
-    unreachable
-L18:
-    r40 = 'is_encodable'
-    r41 = CPyObject_GetAttr(r38, r40)
-    if is_error(r41) goto L21 (error at <module>:15) else goto L19
-L19:
-    faster_eth_abi.packed.is_encodable_packed = r41 :: static
-    r42 = faster_eth_abi.packed.globals :: static
-    r43 = 'is_encodable_packed'
-    r44 = CPyDict_SetItem(r42, r43, r41)
-    dec_ref r41
-    r45 = r44 >= 0 :: signed
-    if not r45 goto L21 (error at <module>:15) else goto L20 :: bool
-L20:
-    return 1
-L21:
-    r46 = <error> :: None
-    return r46
-L22:
-    dec_ref r19
-    goto L21
-
-def ceil32(x):
-    x, r0 :: int
-    r1 :: bit
-    r2, r3, r4, r5, r6 :: int
-L0:
-    r0 = CPyTagged_Remainder(x, 64)
-    if is_error(r0) goto L6 (error at ceil32:21) else goto L1
-L1:
-    r1 = r0 == 0
-    dec_ref r0 :: int
-    if r1 goto L2 else goto L3 :: bool
-L2:
-    inc_ref x :: int
-    r2 = x
-    goto L5
-L3:
-    r3 = CPyTagged_Add(x, 64)
-    r4 = CPyTagged_Remainder(x, 64)
-    if is_error(r4) goto L7 (error at ceil32:22) else goto L4
-L4:
-    r5 = CPyTagged_Subtract(r3, r4)
-    dec_ref r3 :: int
-    dec_ref r4 :: int
-    r2 = r5
-L5:
-    return r2
-L6:
-    r6 = <error> :: int
-    return r6
-L7:
-    dec_ref r3 :: int
-    goto L6
-
-def compute_unsigned_integer_bounds(num_bits):
-    num_bits :: int
-    r0 :: dict
-    r1 :: bool
-    r2, r3 :: object
-    r4, bounds :: union[tuple[int, int], None]
-    r5 :: object
-    r6 :: bit
-    r7, r8, r9, r10, r11 :: object
-    r12 :: tuple[int, object]
-    r13 :: object
-    r14 :: tuple[int, int]
-    r15 :: dict
-    r16 :: bool
-    r17, r18 :: object
-    r19 :: i32
-    r20 :: bit
-    r21, r22 :: tuple[int, int]
-L0:
-    r0 = faster_eth_abi.utils.numeric._unsigned_integer_bounds_cache :: static
-    if is_error(r0) goto L1 else goto L3
-L1:
-    r1 = raise NameError('value for final name "_unsigned_integer_bounds_cache" was not set')
-    if not r1 goto L15 (error at compute_unsigned_integer_bounds:29) else goto L2 :: bool
-L2:
-    unreachable
-L3:
-    inc_ref num_bits :: int
-    r2 = box(int, num_bits)
-    r3 = CPyDict_GetWithNone(r0, r2)
-    dec_ref r2
-    if is_error(r3) goto L15 (error at compute_unsigned_integer_bounds:29) else goto L4
-L4:
-    r4 = cast(union[tuple[int, int], None], r3)
-    if is_error(r4) goto L15 (error at compute_unsigned_integer_bounds:29) else goto L5
-L5:
-    bounds = r4
-    r5 = load_address _Py_NoneStruct
-    r6 = bounds == r5
-    if r6 goto L16 else goto L13 :: bool
-L6:
-    r7 = object 2
-    inc_ref num_bits :: int
-    r8 = box(int, num_bits)
-    r9 = CPyNumber_Power(r7, r8)
-    dec_ref r8
-    if is_error(r9) goto L15 (error at compute_unsigned_integer_bounds:31) else goto L7
-L7:
-    r10 = object 1
-    r11 = PyNumber_Subtract(r9, r10)
-    dec_ref r9
-    if is_error(r11) goto L15 (error at compute_unsigned_integer_bounds:31) else goto L8
-L8:
-    r12 = (0, r11)
-    r13 = box(tuple[int, object], r12)
-    bounds = r13
-    r14 = unbox(tuple[int, int], bounds)
-    if is_error(r14) goto L17 (error at compute_unsigned_integer_bounds:32) else goto L9
-L9:
-    r15 = faster_eth_abi.utils.numeric._unsigned_integer_bounds_cache :: static
-    if is_error(r15) goto L18 else goto L12
-L10:
-    r16 = raise NameError('value for final name "_unsigned_integer_bounds_cache" was not set')
-    if not r16 goto L15 (error at compute_unsigned_integer_bounds:32) else goto L11 :: bool
-L11:
-    unreachable
-L12:
-    inc_ref num_bits :: int
-    r17 = box(int, num_bits)
-    r18 = box(tuple[int, int], r14)
-    r19 = CPyDict_SetItem(r15, r17, r18)
-    dec_ref r17
-    dec_ref r18
-    r20 = r19 >= 0 :: signed
-    if not r20 goto L17 (error at compute_unsigned_integer_bounds:32) else goto L13 :: bool
-L13:
-    r21 = unbox(tuple[int, int], bounds)
-    dec_ref bounds
-    if is_error(r21) goto L15 (error at compute_unsigned_integer_bounds:33) else goto L14
-L14:
-    return r21
-L15:
-    r22 = <error> :: tuple[int, int]
-    return r22
-L16:
-    dec_ref bounds
-    goto L6
-L17:
-    dec_ref bounds
-    goto L15
-L18:
-    dec_ref bounds
-    dec_ref r14
-    goto L10
-
-def compute_signed_integer_bounds(num_bits):
-    num_bits :: int
-    r0 :: dict
-    r1 :: bool
-    r2, r3 :: object
-    r4, bounds :: union[tuple[int, int], None]
-    r5 :: object
-    r6 :: bit
-    r7 :: int
-    r8, r9, r10, r11, r12, r13 :: object
-    r14 :: tuple[object, object]
-    r15 :: object
-    r16 :: tuple[int, int]
-    r17 :: dict
-    r18 :: bool
-    r19, r20 :: object
-    r21 :: i32
-    r22 :: bit
-    r23, r24 :: tuple[int, int]
-L0:
-    r0 = faster_eth_abi.utils.numeric._signed_integer_bounds_cache :: static
-    if is_error(r0) goto L1 else goto L3
-L1:
-    r1 = raise NameError('value for final name "_signed_integer_bounds_cache" was not set')
-    if not r1 goto L16 (error at compute_signed_integer_bounds:40) else goto L2 :: bool
-L2:
-    unreachable
-L3:
-    inc_ref num_bits :: int
-    r2 = box(int, num_bits)
-    r3 = CPyDict_GetWithNone(r0, r2)
-    dec_ref r2
-    if is_error(r3) goto L16 (error at compute_signed_integer_bounds:40) else goto L4
-L4:
-    r4 = cast(union[tuple[int, int], None], r3)
-    if is_error(r4) goto L16 (error at compute_signed_integer_bounds:40) else goto L5
-L5:
-    bounds = r4
-    r5 = load_address _Py_NoneStruct
-    r6 = bounds == r5
-    if r6 goto L17 else goto L14 :: bool
-L6:
-    r7 = CPyTagged_Subtract(num_bits, 2)
-    r8 = object 2
-    r9 = box(int, r7)
-    r10 = CPyNumber_Power(r8, r9)
-    dec_ref r9
-    if is_error(r10) goto L16 (error at compute_signed_integer_bounds:42) else goto L7
-L7:
-    r11 = PyNumber_Negative(r10)
-    if is_error(r11) goto L18 (error at compute_signed_integer_bounds:43) else goto L8
-L8:
-    r12 = object 1
-    r13 = PyNumber_Subtract(r10, r12)
-    dec_ref r10
-    if is_error(r13) goto L19 (error at compute_signed_integer_bounds:44) else goto L9
-L9:
-    r14 = (r11, r13)
-    r15 = box(tuple[object, object], r14)
-    bounds = r15
-    r16 = unbox(tuple[int, int], bounds)
-    if is_error(r16) goto L20 (error at compute_signed_integer_bounds:46) else goto L10
-L10:
-    r17 = faster_eth_abi.utils.numeric._signed_integer_bounds_cache :: static
-    if is_error(r17) goto L21 else goto L13
-L11:
-    r18 = raise NameError('value for final name "_signed_integer_bounds_cache" was not set')
-    if not r18 goto L16 (error at compute_signed_integer_bounds:46) else goto L12 :: bool
-L12:
-    unreachable
-L13:
-    inc_ref num_bits :: int
-    r19 = box(int, num_bits)
-    r20 = box(tuple[int, int], r16)
-    r21 = CPyDict_SetItem(r17, r19, r20)
-    dec_ref r19
-    dec_ref r20
-    r22 = r21 >= 0 :: signed
-    if not r22 goto L20 (error at compute_signed_integer_bounds:46) else goto L14 :: bool
-L14:
-    r23 = unbox(tuple[int, int], bounds)
-    dec_ref bounds
-    if is_error(r23) goto L16 (error at compute_signed_integer_bounds:47) else goto L15
-L15:
-    return r23
-L16:
-    r24 = <error> :: tuple[int, int]
-    return r24
-L17:
-    dec_ref bounds
-    goto L6
-L18:
-    dec_ref r10
-    goto L16
-L19:
-    dec_ref r11
-    goto L16
-L20:
-    dec_ref bounds
-    goto L16
-L21:
-    dec_ref bounds
-    dec_ref r16
-    goto L11
-
-def compute_unsigned_fixed_bounds(num_bits, frac_places):
-    num_bits, frac_places :: int
-    r0 :: dict
-    r1 :: bool
-    r2 :: tuple[int, int]
-    r3, r4 :: object
-    upper :: union[object, None]
-    r5 :: object
-    r6 :: bit
-    r7 :: int
-    r8, r9, r10, r11, r12, r13 :: object
-    r14 :: bool
-    r15 :: object
-    r16 :: bool
-    r17 :: object[1]
-    r18 :: object_ptr
-    r19, r20 :: object
-    r21 :: str
-    r22 :: object
-    r23 :: str
-    r24 :: object
-    r25 :: object[1]
-    r26 :: object_ptr
-    r27 :: object
-    r28 :: bool
-    r29 :: object
-    r30 :: bool
-    r31 :: object[1]
-    r32 :: object_ptr
-    r33, r34 :: object
-    r35 :: bool
-    r36 :: int
-    r37, r38, r39 :: object
-    r40, r41 :: tuple[object, object, object]
-    r42, r43, r44 :: object
-    r45 :: object[4]
-    r46 :: object_ptr
-    r47 :: object
-    r48 :: i32
-    r49 :: bit
-    r50 :: bool
-    r51 :: bit
-    r52, r53, r54 :: tuple[object, object, object]
-    r55 :: object
-    r56 :: object[4]
-    r57 :: object_ptr
-    r58 :: object
-    r59 :: bit
-    r60 :: dict
-    r61 :: bool
-    r62 :: tuple[int, int]
-    r63 :: object
-    r64 :: i32
-    r65 :: bit
-    r66 :: object
-    r67 :: bool
-    r68 :: tuple[object, union[object, None]]
-    r69 :: tuple[object, object]
-L0:
-    r0 = faster_eth_abi.utils.numeric._unsigned_fixed_bounds_cache :: static
-    if is_error(r0) goto L1 else goto L3
-L1:
-    r1 = raise NameError('value for final name "_unsigned_fixed_bounds_cache" was not set')
-    if not r1 goto L56 (error at compute_unsigned_fixed_bounds:57) else goto L2 :: bool
-L2:
-    unreachable
-L3:
-    inc_ref num_bits :: int
-    inc_ref frac_places :: int
-    r2 = (num_bits, frac_places)
-    r3 = box(tuple[int, int], r2)
-    r4 = CPyDict_GetWithNone(r0, r3)
-    dec_ref r3
-    if is_error(r4) goto L56 (error at compute_unsigned_fixed_bounds:57) else goto L4
-L4:
-    upper = r4
-    r5 = load_address _Py_NoneStruct
-    r6 = upper == r5
-    if r6 goto L5 else goto L52 :: bool
-L5:
-    r7 = CPyTagged_Subtract(num_bits, 2)
-    r8 = object 2
-    r9 = box(int, r7)
-    r10 = CPyNumber_Power(r8, r9)
-    dec_ref r9
-    if is_error(r10) goto L57 (error at compute_unsigned_fixed_bounds:59) else goto L6
-L6:
-    r11 = object 1
-    r12 = PyNumber_Subtract(r10, r11)
-    dec_ref r10
-    if is_error(r12) goto L57 (error at compute_unsigned_fixed_bounds:59) else goto L7
-L7:
-    r13 = faster_eth_abi.utils.numeric.abi_decimal_context :: static
-    if is_error(r13) goto L58 else goto L10
-L8:
-    r14 = raise NameError('value for final name "abi_decimal_context" was not set')
-    if not r14 goto L56 (error at compute_unsigned_fixed_bounds:61) else goto L9 :: bool
-L9:
-    unreachable
-L10:
-    r15 = faster_eth_abi.utils.numeric.decimal_localcontext :: static
-    if is_error(r15) goto L59 else goto L13
-L11:
-    r16 = raise NameError('value for final name "decimal_localcontext" was not set')
-    if not r16 goto L56 (error at compute_unsigned_fixed_bounds:61) else goto L12 :: bool
-L12:
-    unreachable
-L13:
-    r17 = [r13]
-    r18 = load_address r17
-    r19 = PyObject_Vectorcall(r15, r18, 1, 0)
-    if is_error(r19) goto L60 (error at compute_unsigned_fixed_bounds:61) else goto L14
-L14:
-    r20 = CPy_TYPE(r19)
-    r21 = '__exit__'
-    r22 = CPyObject_GetAttr(r20, r21)
-    if is_error(r22) goto L61 (error at compute_unsigned_fixed_bounds:61) else goto L15
-L15:
-    r23 = '__enter__'
-    r24 = CPyObject_GetAttr(r20, r23)
-    dec_ref r20
-    if is_error(r24) goto L62 (error at compute_unsigned_fixed_bounds:61) else goto L16
-L16:
-    r25 = [r19]
-    r26 = load_address r25
-    r27 = PyObject_Vectorcall(r24, r26, 1, 0)
-    dec_ref r24
-    if is_error(r27) goto L62 (error at compute_unsigned_fixed_bounds:61) else goto L63
-L17:
-    r28 = 1
-L18:
-    r29 = faster_eth_abi.utils.numeric.Decimal :: static
-    if is_error(r29) goto L64 else goto L21
-L19:
-    r30 = raise NameError('value for final name "Decimal" was not set')
-    if not r30 goto L28 (error at compute_unsigned_fixed_bounds:62) else goto L65 :: bool
-L20:
-    unreachable
-L21:
-    r31 = [r12]
-    r32 = load_address r31
-    r33 = PyObject_Vectorcall(r29, r32, 1, 0)
-    if is_error(r33) goto L66 (error at compute_unsigned_fixed_bounds:62) else goto L22
-L22:
-    dec_ref r12
-    r34 = faster_eth_abi.utils.numeric.TEN :: static
-    if is_error(r34) goto L67 else goto L25
-L23:
-    r35 = raise NameError('value for final name "TEN" was not set')
-    if not r35 goto L28 (error at compute_unsigned_fixed_bounds:62) else goto L68 :: bool
-L24:
-    unreachable
-L25:
-    r36 = CPyTagged_Negate(frac_places)
-    r37 = box(int, r36)
-    r38 = CPyNumber_Power(r34, r37)
-    dec_ref r37
-    if is_error(r38) goto L69 (error at compute_unsigned_fixed_bounds:62) else goto L26
-L26:
-    r39 = PyNumber_Multiply(r33, r38)
-    dec_ref r33
-    dec_ref r38
-    if is_error(r39) goto L28 (error at compute_unsigned_fixed_bounds:62) else goto L70
-L27:
-    upper = r39
-    goto L36
-L28:
-    r40 = CPy_CatchError()
-    r28 = 0
-    r41 = CPy_GetExcInfo()
-    r42 = r41[0]
-    r43 = r41[1]
-    r44 = r41[2]
-    dec_ref r41
-    r45 = [r19, r42, r43, r44]
-    r46 = load_address r45
-    r47 = PyObject_Vectorcall(r22, r46, 4, 0)
-    if is_error(r47) goto L71 (error at compute_unsigned_fixed_bounds:61) else goto L29
-L29:
-    dec_ref r42
-    dec_ref r43
-    dec_ref r44
-    r48 = PyObject_IsTrue(r47)
-    dec_ref r47
-    r49 = r48 >= 0 :: signed
-    if not r49 goto L34 (error at compute_unsigned_fixed_bounds:61) else goto L30 :: bool
-L30:
-    r50 = truncate r48: i32 to builtins.bool
-    if r50 goto L33 else goto L31 :: bool
-L31:
-    CPy_Reraise()
-    if not 0 goto L34 else goto L72 :: bool
-L32:
-    unreachable
-L33:
-    CPy_RestoreExcInfo(r40)
-    dec_ref r40
-    goto L36
-L34:
-    CPy_RestoreExcInfo(r40)
-    dec_ref r40
-    r51 = CPy_KeepPropagating()
-    if not r51 goto L37 else goto L73 :: bool
-L35:
-    unreachable
-L36:
-    r52 = <error> :: tuple[object, object, object]
-    r53 = r52
-    goto L38
-L37:
-    r54 = CPy_CatchError()
-    r53 = r54
-L38:
-    if r28 goto L39 else goto L74 :: bool
-L39:
-    r55 = load_address _Py_NoneStruct
-    r56 = [r19, r55, r55, r55]
-    r57 = load_address r56
-    r58 = PyObject_Vectorcall(r22, r57, 4, 0)
-    dec_ref r22
-    if is_error(r58) goto L75 (error at compute_unsigned_fixed_bounds:61) else goto L76
-L40:
-    dec_ref r19
-L41:
-    if is_error(r53) goto L48 else goto L77
-L42:
-    CPy_Reraise()
-    if not 0 goto L44 else goto L78 :: bool
-L43:
-    unreachable
-L44:
-    if is_error(r53) goto L46 else goto L45
-L45:
-    CPy_RestoreExcInfo(r53)
-    xdec_ref r53
-L46:
-    r59 = CPy_KeepPropagating()
-    if not r59 goto L56 else goto L47 :: bool
-L47:
-    unreachable
-L48:
-    r60 = faster_eth_abi.utils.numeric._unsigned_fixed_bounds_cache :: static
-    if is_error(r60) goto L79 else goto L51
-L49:
-    r61 = raise NameError('value for final name "_unsigned_fixed_bounds_cache" was not set')
-    if not r61 goto L56 (error at compute_unsigned_fixed_bounds:64) else goto L50 :: bool
-L50:
-    unreachable
-L51:
-    inc_ref num_bits :: int
-    inc_ref frac_places :: int
-    r62 = (num_bits, frac_places)
-    r63 = box(tuple[int, int], r62)
-    r64 = CPyDict_SetItem(r60, r63, upper)
-    dec_ref r63
-    r65 = r64 >= 0 :: signed
-    if not r65 goto L57 (error at compute_unsigned_fixed_bounds:64) else goto L52 :: bool
-L52:
-    r66 = faster_eth_abi.utils.numeric.ZERO :: static
-    if is_error(r66) goto L80 else goto L55
-L53:
-    r67 = raise NameError('value for final name "ZERO" was not set')
-    if not r67 goto L56 (error at compute_unsigned_fixed_bounds:66) else goto L54 :: bool
-L54:
-    unreachable
-L55:
-    inc_ref r66
-    r68 = (r66, upper)
-    return r68
-L56:
-    r69 = <error> :: tuple[object, object]
-    return r69
-L57:
-    dec_ref upper
-    goto L56
-L58:
-    dec_ref upper
-    dec_ref r12
-    goto L8
-L59:
-    dec_ref upper
-    dec_ref r12
-    goto L11
-L60:
-    dec_ref upper
-    dec_ref r12
-    goto L56
-L61:
-    dec_ref upper
-    dec_ref r12
-    dec_ref r19
-    dec_ref r20
-    goto L56
-L62:
-    dec_ref upper
-    dec_ref r12
-    dec_ref r19
-    dec_ref r22
-    goto L56
-L63:
-    dec_ref r27
-    goto L17
-L64:
-    dec_ref r12
-    goto L19
-L65:
-    dec_ref upper
-    dec_ref r19
-    dec_ref r22
-    goto L20
-L66:
-    dec_ref r12
-    goto L28
-L67:
-    dec_ref r33
-    goto L23
-L68:
-    dec_ref upper
-    dec_ref r19
-    dec_ref r22
-    goto L24
-L69:
-    dec_ref r33
-    goto L28
-L70:
-    dec_ref upper
-    goto L27
-L71:
-    dec_ref r42
-    dec_ref r43
-    dec_ref r44
-    goto L34
-L72:
-    dec_ref upper
-    dec_ref r19
-    dec_ref r22
-    dec_ref r40
-    goto L32
-L73:
-    dec_ref upper
-    dec_ref r19
-    dec_ref r22
-    goto L35
-L74:
-    dec_ref r19
-    dec_ref r22
-    goto L41
-L75:
-    dec_ref upper
-    dec_ref r19
-    goto L44
-L76:
-    dec_ref r58
-    goto L40
-L77:
-    dec_ref upper
-    goto L42
-L78:
-    xdec_ref r53
-    goto L43
-L79:
-    dec_ref upper
-    goto L49
-L80:
-    dec_ref upper
-    goto L53
-
-def compute_signed_fixed_bounds(num_bits, frac_places):
-    num_bits, frac_places :: int
-    r0, lower, r1, upper :: object
-    r2 :: dict
-    r3 :: bool
-    r4 :: tuple[int, int]
-    r5, r6 :: object
-    r7, bounds :: union[tuple[object, object], None]
-    r8 :: object
-    r9 :: bit
-    r10 :: tuple[int, int]
-    r11, r12, r13, r14 :: int
-    r15 :: object
-    r16 :: bool
-    r17 :: object
-    r18 :: bool
-    r19 :: object[1]
-    r20 :: object_ptr
-    r21, r22 :: object
-    r23 :: str
-    r24 :: object
-    r25 :: str
-    r26 :: object
-    r27 :: object[1]
-    r28 :: object_ptr
-    r29 :: object
-    r30 :: bool
-    r31 :: object
-    r32 :: bool
-    r33 :: int
-    r34, r35, r36 :: object
-    r37 :: bool
-    r38 :: object
-    r39 :: object[1]
-    r40 :: object_ptr
-    r41, r42, r43 :: object
-    r44 :: bool
-    r45 :: object
-    r46 :: object[1]
-    r47 :: object_ptr
-    r48, r49 :: object
-    r50, r51 :: tuple[object, object, object]
-    r52, r53, r54 :: object
-    r55 :: object[4]
-    r56 :: object_ptr
-    r57 :: object
-    r58 :: i32
-    r59 :: bit
-    r60 :: bool
-    r61 :: bit
-    r62, r63, r64 :: tuple[object, object, object]
-    r65 :: object
-    r66 :: object[4]
-    r67 :: object_ptr
-    r68 :: object
-    r69 :: bit
-    r70, r71 :: bool
-    r72 :: tuple[object, object]
-    r73 :: object
-    r74 :: tuple[object, object]
-    r75 :: dict
-    r76 :: bool
-    r77 :: tuple[int, int]
-    r78, r79 :: object
-    r80 :: i32
-    r81 :: bit
-    r82, r83 :: tuple[object, object]
-L0:
-    r0 = <error> :: object
-    lower = r0
-    r1 = <error> :: object
-    upper = r1
-    r2 = faster_eth_abi.utils.numeric._signed_fixed_bounds_cache :: static
-    if is_error(r2) goto L67 else goto L3
-L1:
-    r3 = raise NameError('value for final name "_signed_fixed_bounds_cache" was not set')
-    if not r3 goto L66 (error at compute_signed_fixed_bounds:76) else goto L2 :: bool
-L2:
-    unreachable
-L3:
-    inc_ref num_bits :: int
-    inc_ref frac_places :: int
-    r4 = (num_bits, frac_places)
-    r5 = box(tuple[int, int], r4)
-    r6 = CPyDict_GetWithNone(r2, r5)
-    dec_ref r5
-    if is_error(r6) goto L68 (error at compute_signed_fixed_bounds:76) else goto L4
-L4:
-    r7 = cast(union[tuple[object, object], None], r6)
-    if is_error(r7) goto L68 (error at compute_signed_fixed_bounds:76) else goto L5
-L5:
-    bounds = r7
-    r8 = load_address _Py_NoneStruct
-    r9 = bounds == r8
-    if r9 goto L69 else goto L70 :: bool
-L6:
-    r10 = compute_signed_integer_bounds(num_bits)
-    if is_error(r10) goto L68 (error at compute_signed_fixed_bounds:78) else goto L7
-L7:
-    r11 = borrow r10[0]
-    r12 = borrow r10[1]
-    r13 = unborrow r11
-    r14 = unborrow r12
-    r15 = faster_eth_abi.utils.numeric.abi_decimal_context :: static
-    if is_error(r15) goto L71 else goto L10
-L8:
-    r16 = raise NameError('value for final name "abi_decimal_context" was not set')
-    if not r16 goto L66 (error at compute_signed_fixed_bounds:80) else goto L9 :: bool
-L9:
-    unreachable
-L10:
-    r17 = faster_eth_abi.utils.numeric.decimal_localcontext :: static
-    if is_error(r17) goto L72 else goto L13
-L11:
-    r18 = raise NameError('value for final name "decimal_localcontext" was not set')
-    if not r18 goto L66 (error at compute_signed_fixed_bounds:80) else goto L12 :: bool
-L12:
-    unreachable
-L13:
-    r19 = [r15]
-    r20 = load_address r19
-    r21 = PyObject_Vectorcall(r17, r20, 1, 0)
-    if is_error(r21) goto L73 (error at compute_signed_fixed_bounds:80) else goto L14
-L14:
-    r22 = CPy_TYPE(r21)
-    r23 = '__exit__'
-    r24 = CPyObject_GetAttr(r22, r23)
-    if is_error(r24) goto L74 (error at compute_signed_fixed_bounds:80) else goto L15
-L15:
-    r25 = '__enter__'
-    r26 = CPyObject_GetAttr(r22, r25)
-    dec_ref r22
-    if is_error(r26) goto L75 (error at compute_signed_fixed_bounds:80) else goto L16
-L16:
-    r27 = [r21]
-    r28 = load_address r27
-    r29 = PyObject_Vectorcall(r26, r28, 1, 0)
-    dec_ref r26
-    if is_error(r29) goto L75 (error at compute_signed_fixed_bounds:80) else goto L76
-L17:
-    r30 = 1
-L18:
-    r31 = faster_eth_abi.utils.numeric.TEN :: static
-    if is_error(r31) goto L77 else goto L21
-L19:
-    r32 = raise NameError('value for final name "TEN" was not set')
-    if not r32 goto L33 (error at compute_signed_fixed_bounds:81) else goto L78 :: bool
-L20:
-    unreachable
-L21:
-    r33 = CPyTagged_Negate(frac_places)
-    r34 = box(int, r33)
-    r35 = CPyNumber_Power(r31, r34)
-    dec_ref r34
-    if is_error(r35) goto L79 (error at compute_signed_fixed_bounds:81) else goto L22
-L22:
-    r36 = faster_eth_abi.utils.numeric.Decimal :: static
-    if is_error(r36) goto L80 else goto L25
-L23:
-    r37 = raise NameError('value for final name "Decimal" was not set')
-    if not r37 goto L33 (error at compute_signed_fixed_bounds:82) else goto L81 :: bool
-L24:
-    unreachable
-L25:
-    r38 = box(int, r13)
-    r39 = [r38]
-    r40 = load_address r39
-    r41 = PyObject_Vectorcall(r36, r40, 1, 0)
-    if is_error(r41) goto L82 (error at compute_signed_fixed_bounds:82) else goto L26
-L26:
-    dec_ref r38
-    r42 = PyNumber_Multiply(r41, r35)
-    dec_ref r41
-    if is_error(r42) goto L83 (error at compute_signed_fixed_bounds:82) else goto L84
-L27:
-    lower = r42
-    r43 = faster_eth_abi.utils.numeric.Decimal :: static
-    if is_error(r43) goto L85 else goto L30
-L28:
-    r44 = raise NameError('value for final name "Decimal" was not set')
-    if not r44 goto L33 (error at compute_signed_fixed_bounds:83) else goto L86 :: bool
-L29:
-    unreachable
-L30:
-    r45 = box(int, r14)
-    r46 = [r45]
-    r47 = load_address r46
-    r48 = PyObject_Vectorcall(r43, r47, 1, 0)
-    if is_error(r48) goto L87 (error at compute_signed_fixed_bounds:83) else goto L31
-L31:
-    dec_ref r45
-    r49 = PyNumber_Multiply(r48, r35)
-    dec_ref r48
-    dec_ref r35
-    if is_error(r49) goto L33 (error at compute_signed_fixed_bounds:83) else goto L88
-L32:
-    upper = r49
-    goto L41
-L33:
-    r50 = CPy_CatchError()
-    r30 = 0
-    r51 = CPy_GetExcInfo()
-    r52 = r51[0]
-    r53 = r51[1]
-    r54 = r51[2]
-    dec_ref r51
-    r55 = [r21, r52, r53, r54]
-    r56 = load_address r55
-    r57 = PyObject_Vectorcall(r24, r56, 4, 0)
-    if is_error(r57) goto L89 (error at compute_signed_fixed_bounds:80) else goto L34
-L34:
-    dec_ref r52
-    dec_ref r53
-    dec_ref r54
-    r58 = PyObject_IsTrue(r57)
-    dec_ref r57
-    r59 = r58 >= 0 :: signed
-    if not r59 goto L39 (error at compute_signed_fixed_bounds:80) else goto L35 :: bool
-L35:
-    r60 = truncate r58: i32 to builtins.bool
-    if r60 goto L38 else goto L36 :: bool
-L36:
-    CPy_Reraise()
-    if not 0 goto L39 else goto L90 :: bool
-L37:
-    unreachable
-L38:
-    CPy_RestoreExcInfo(r50)
-    dec_ref r50
-    goto L41
-L39:
-    CPy_RestoreExcInfo(r50)
-    dec_ref r50
-    r61 = CPy_KeepPropagating()
-    if not r61 goto L42 else goto L91 :: bool
-L40:
-    unreachable
-L41:
-    r62 = <error> :: tuple[object, object, object]
-    r63 = r62
-    goto L43
-L42:
-    r64 = CPy_CatchError()
-    r63 = r64
-L43:
-    if r30 goto L44 else goto L92 :: bool
-L44:
-    r65 = load_address _Py_NoneStruct
-    r66 = [r21, r65, r65, r65]
-    r67 = load_address r66
-    r68 = PyObject_Vectorcall(r24, r67, 4, 0)
-    dec_ref r24
-    if is_error(r68) goto L93 (error at compute_signed_fixed_bounds:80) else goto L94
-L45:
-    dec_ref r21
-L46:
-    if is_error(r63) goto L53 else goto L95
-L47:
-    CPy_Reraise()
-    if not 0 goto L49 else goto L96 :: bool
-L48:
-    unreachable
-L49:
-    if is_error(r63) goto L51 else goto L50
-L50:
-    CPy_RestoreExcInfo(r63)
-    xdec_ref r63
-L51:
-    r69 = CPy_KeepPropagating()
-    if not r69 goto L66 else goto L52 :: bool
-L52:
-    unreachable
-L53:
-    if is_error(lower) goto L97 else goto L56
-L54:
-    r70 = raise UnboundLocalError('local variable "lower" referenced before assignment')
-    if not r70 goto L66 (error at compute_signed_fixed_bounds:85) else goto L55 :: bool
-L55:
-    unreachable
-L56:
-    if is_error(upper) goto L98 else goto L59
-L57:
-    r71 = raise UnboundLocalError('local variable "upper" referenced before assignment')
-    if not r71 goto L66 (error at compute_signed_fixed_bounds:85) else goto L58 :: bool
-L58:
-    unreachable
-L59:
-    r72 = (lower, upper)
-    r73 = box(tuple[object, object], r72)
-    bounds = r73
-    r74 = unbox(tuple[object, object], bounds)
-    if is_error(r74) goto L99 (error at compute_signed_fixed_bounds:86) else goto L60
-L60:
-    r75 = faster_eth_abi.utils.numeric._signed_fixed_bounds_cache :: static
-    if is_error(r75) goto L100 else goto L63
-L61:
-    r76 = raise NameError('value for final name "_signed_fixed_bounds_cache" was not set')
-    if not r76 goto L66 (error at compute_signed_fixed_bounds:86) else goto L62 :: bool
-L62:
-    unreachable
-L63:
-    inc_ref num_bits :: int
-    inc_ref frac_places :: int
-    r77 = (num_bits, frac_places)
-    r78 = box(tuple[int, int], r77)
-    r79 = box(tuple[object, object], r74)
-    r80 = CPyDict_SetItem(r75, r78, r79)
-    dec_ref r78
-    dec_ref r79
-    r81 = r80 >= 0 :: signed
-    if not r81 goto L99 (error at compute_signed_fixed_bounds:86) else goto L64 :: bool
-L64:
-    r82 = unbox(tuple[object, object], bounds)
-    dec_ref bounds
-    if is_error(r82) goto L66 (error at compute_signed_fixed_bounds:88) else goto L65
-L65:
-    return r82
-L66:
-    r83 = <error> :: tuple[object, object]
-    return r83
-L67:
-    xdec_ref lower
-    xdec_ref upper
-    goto L1
-L68:
-    xdec_ref lower
-    xdec_ref upper
-    goto L66
-L69:
-    dec_ref bounds
-    goto L6
-L70:
-    xdec_ref lower
-    xdec_ref upper
-    goto L64
-L71:
-    xdec_ref lower
-    xdec_ref upper
-    dec_ref r13 :: int
-    dec_ref r14 :: int
-    goto L8
-L72:
-    xdec_ref lower
-    xdec_ref upper
-    dec_ref r13 :: int
-    dec_ref r14 :: int
-    goto L11
-L73:
-    xdec_ref lower
-    xdec_ref upper
-    dec_ref r13 :: int
-    dec_ref r14 :: int
-    goto L66
-L74:
-    xdec_ref lower
-    xdec_ref upper
-    dec_ref r13 :: int
-    dec_ref r14 :: int
-    dec_ref r21
-    dec_ref r22
-    goto L66
-L75:
-    xdec_ref lower
-    xdec_ref upper
-    dec_ref r13 :: int
-    dec_ref r14 :: int
-    dec_ref r21
-    dec_ref r24
-    goto L66
-L76:
-    dec_ref r29
-    goto L17
-L77:
-    dec_ref r13 :: int
-    dec_ref r14 :: int
-    goto L19
-L78:
-    xdec_ref lower
-    xdec_ref upper
-    dec_ref r21
-    dec_ref r24
-    goto L20
-L79:
-    dec_ref r13 :: int
-    dec_ref r14 :: int
-    goto L33
-L80:
-    dec_ref r13 :: int
-    dec_ref r14 :: int
-    dec_ref r35
-    goto L23
-L81:
-    xdec_ref lower
-    xdec_ref upper
-    dec_ref r21
-    dec_ref r24
-    goto L24
-L82:
-    dec_ref r14 :: int
-    dec_ref r35
-    dec_ref r38
-    goto L33
-L83:
-    dec_ref r14 :: int
-    dec_ref r35
-    goto L33
-L84:
-    xdec_ref lower
-    goto L27
-L85:
-    dec_ref r14 :: int
-    dec_ref r35
-    goto L28
-L86:
-    dec_ref lower
-    xdec_ref upper
-    dec_ref r21
-    dec_ref r24
-    goto L29
-L87:
-    dec_ref r35
-    dec_ref r45
-    goto L33
-L88:
-    xdec_ref upper
-    goto L32
-L89:
-    dec_ref r52
-    dec_ref r53
-    dec_ref r54
-    goto L39
-L90:
-    xdec_ref lower
-    xdec_ref upper
-    dec_ref r21
-    dec_ref r24
-    dec_ref r50
-    goto L37
-L91:
-    xdec_ref lower
-    xdec_ref upper
-    dec_ref r21
-    dec_ref r24
-    goto L40
-L92:
-    dec_ref r21
-    dec_ref r24
-    goto L46
-L93:
-    xdec_ref lower
-    xdec_ref upper
-    dec_ref r21
-    goto L49
-L94:
-    dec_ref r68
-    goto L45
-L95:
-    xdec_ref lower
-    xdec_ref upper
-    goto L47
-L96:
-    xdec_ref r63
-    goto L48
-L97:
-    xdec_ref upper
-    goto L54
-L98:
-    xdec_ref lower
-    goto L57
-L99:
-    dec_ref bounds
-    goto L66
-L100:
-    dec_ref bounds
-    dec_ref r74
-    goto L61
-
-def f_scale_places_obj.__get__(__mypyc_self__, instance, owner):
-    __mypyc_self__, instance, owner, r0 :: object
-    r1 :: bit
-    r2, r3 :: object
-L0:
-    r0 = load_address _Py_NoneStruct
-    r1 = instance == r0
-    if r1 goto L1 else goto L2 :: bool
-L1:
-    inc_ref __mypyc_self__
-    return __mypyc_self__
-L2:
-    r2 = PyMethod_New(__mypyc_self__, instance)
-    if is_error(r2) goto L4 else goto L3
-L3:
-    return r2
-L4:
-    r3 = <error> :: object
-    return r3
-
-def f_scale_places_obj.__call__(__mypyc_self__, x):
-    __mypyc_self__ :: faster_eth_abi.utils.numeric.f_scale_places_obj
-    x :: object
-    r0 :: faster_eth_abi.utils.numeric.scale_places_env
-    r1 :: object
-    r2 :: bool
-    r3 :: object
-    r4 :: bool
-    r5 :: object[1]
-    r6 :: object_ptr
-    r7, r8 :: object
-    r9 :: str
-    r10 :: object
-    r11 :: str
-    r12 :: object
-    r13 :: object[1]
-    r14 :: object_ptr
-    r15 :: object
-    r16 :: bool
-    r17, r18, r19 :: object
-    r20, r21 :: tuple[object, object, object]
-    r22, r23, r24 :: object
-    r25 :: object[4]
-    r26 :: object_ptr
-    r27 :: object
-    r28 :: i32
-    r29 :: bit
-    r30 :: bool
-    r31 :: bit
-    r32 :: object
-    r33, r34 :: tuple[object, object, object]
-    r35 :: object
-    r36 :: tuple[object, object, object]
-    r37 :: object
-    r38 :: object[4]
-    r39 :: object_ptr
-    r40 :: object
-    r41 :: bit
-    r42, r43 :: object
-L0:
-    r0 = __mypyc_self__.__mypyc_env__
-    if is_error(r0) goto L39 (error at f:105) else goto L1
-L1:
-    r1 = faster_eth_abi.utils.numeric.abi_decimal_context :: static
-    if is_error(r1) goto L40 else goto L4
-L2:
-    r2 = raise NameError('value for final name "abi_decimal_context" was not set')
-    if not r2 goto L39 (error at f:106) else goto L3 :: bool
-L3:
-    unreachable
-L4:
-    r3 = faster_eth_abi.utils.numeric.decimal_localcontext :: static
-    if is_error(r3) goto L41 else goto L7
-L5:
-    r4 = raise NameError('value for final name "decimal_localcontext" was not set')
-    if not r4 goto L39 (error at f:106) else goto L6 :: bool
-L6:
-    unreachable
-L7:
-    r5 = [r1]
-    r6 = load_address r5
-    r7 = PyObject_Vectorcall(r3, r6, 1, 0)
-    if is_error(r7) goto L42 (error at f:106) else goto L8
-L8:
-    r8 = CPy_TYPE(r7)
-    r9 = '__exit__'
-    r10 = CPyObject_GetAttr(r8, r9)
-    if is_error(r10) goto L43 (error at f:106) else goto L9
-L9:
-    r11 = '__enter__'
-    r12 = CPyObject_GetAttr(r8, r11)
-    dec_ref r8
-    if is_error(r12) goto L44 (error at f:106) else goto L10
-L10:
-    r13 = [r7]
-    r14 = load_address r13
-    r15 = PyObject_Vectorcall(r12, r14, 1, 0)
-    dec_ref r12
-    if is_error(r15) goto L44 (error at f:106) else goto L45
-L11:
-    r16 = 1
-L12:
-    r17 = r0.scaling_factor
-    dec_ref r0
-    if is_error(r17) goto L15 (error at f:107) else goto L13
-L13:
-    r18 = PyNumber_Multiply(x, r17)
-    dec_ref r17
-    if is_error(r18) goto L15 (error at f:107) else goto L14
-L14:
-    r19 = r18
-    goto L24
-L15:
-    r20 = CPy_CatchError()
-    r16 = 0
-    r21 = CPy_GetExcInfo()
-    r22 = r21[0]
-    r23 = r21[1]
-    r24 = r21[2]
-    dec_ref r21
-    r25 = [r7, r22, r23, r24]
-    r26 = load_address r25
-    r27 = PyObject_Vectorcall(r10, r26, 4, 0)
-    if is_error(r27) goto L46 (error at f:106) else goto L16
-L16:
-    dec_ref r22
-    dec_ref r23
-    dec_ref r24
-    r28 = PyObject_IsTrue(r27)
-    dec_ref r27
-    r29 = r28 >= 0 :: signed
-    if not r29 goto L21 (error at f:106) else goto L17 :: bool
-L17:
-    r30 = truncate r28: i32 to builtins.bool
-    if r30 goto L20 else goto L18 :: bool
-L18:
-    CPy_Reraise()
-    if not 0 goto L21 else goto L47 :: bool
-L19:
-    unreachable
-L20:
-    CPy_RestoreExcInfo(r20)
-    dec_ref r20
-    goto L23
-L21:
-    CPy_RestoreExcInfo(r20)
-    dec_ref r20
-    r31 = CPy_KeepPropagating()
-    if not r31 goto L25 else goto L48 :: bool
-L22:
-    unreachable
-L23:
-    r32 = <error> :: object
-    r19 = r32
-L24:
-    r33 = <error> :: tuple[object, object, object]
-    r34 = r33
-    goto L26
-L25:
-    r35 = <error> :: object
-    r19 = r35
-    r36 = CPy_CatchError()
-    r34 = r36
-L26:
-    if r16 goto L27 else goto L49 :: bool
-L27:
-    r37 = load_address _Py_NoneStruct
-    r38 = [r7, r37, r37, r37]
-    r39 = load_address r38
-    r40 = PyObject_Vectorcall(r10, r39, 4, 0)
-    dec_ref r10
-    if is_error(r40) goto L50 (error at f:106) else goto L51
-L28:
-    dec_ref r7
-L29:
-    if is_error(r34) goto L32 else goto L52
-L30:
-    CPy_Reraise()
-    if not 0 goto L34 else goto L53 :: bool
-L31:
-    unreachable
-L32:
-    if is_error(r19) goto L38 else goto L33
-L33:
-    return r19
-L34:
-    if is_error(r34) goto L36 else goto L35
-L35:
-    CPy_RestoreExcInfo(r34)
-    xdec_ref r34
-L36:
-    r41 = CPy_KeepPropagating()
-    if not r41 goto L39 else goto L37 :: bool
-L37:
-    unreachable
-L38:
-    r42 = box(None, 1)
-    inc_ref r42
-    return r42
-L39:
-    r43 = <error> :: object
-    return r43
-L40:
-    dec_ref r0
-    goto L2
-L41:
-    dec_ref r0
-    goto L5
-L42:
-    dec_ref r0
-    goto L39
-L43:
-    dec_ref r0
-    dec_ref r7
-    dec_ref r8
-    goto L39
-L44:
-    dec_ref r0
-    dec_ref r7
-    dec_ref r10
-    goto L39
-L45:
-    dec_ref r15
-    goto L11
-L46:
-    dec_ref r22
-    dec_ref r23
-    dec_ref r24
-    goto L21
-L47:
-    dec_ref r7
-    dec_ref r10
-    dec_ref r20
-    goto L19
-L48:
-    dec_ref r7
-    dec_ref r10
-    goto L22
-L49:
-    dec_ref r7
-    dec_ref r10
-    goto L29
-L50:
-    dec_ref r7
-    xdec_ref r19
-    goto L34
-L51:
-    dec_ref r40
-    goto L28
-L52:
-    xdec_ref r19
-    goto L30
-L53:
-    xdec_ref r34
-    goto L31
-
-def scale_places(places):
-    places :: int
-    r0 :: faster_eth_abi.utils.numeric.scale_places_env
-    r1 :: object
-    r2 :: bit
-    r3, r4, r5 :: str
-    r6 :: object
-    r7, r8 :: str
-    r9 :: object[3]
-    r10 :: object_ptr
-    r11 :: object
-    r12, r13 :: str
-    r14, r15 :: object
-    r16, r17 :: str
-    r18 :: object[3]
-    r19 :: object_ptr
-    r20 :: object
-    r21 :: str
-    r22 :: list
-    r23, r24, r25, r26, r27, r28 :: ptr
-    r29 :: str
-    r30 :: object
-    r31 :: str
-    r32 :: object
-    r33 :: object[1]
-    r34 :: object_ptr
-    r35, r36 :: object
-    r37 :: bool
-    r38 :: object
-    r39 :: bool
-    r40 :: object[1]
-    r41 :: object_ptr
-    r42, r43 :: object
-    r44 :: str
-    r45 :: object
-    r46 :: str
-    r47 :: object
-    r48 :: object[1]
-    r49 :: object_ptr
-    r50 :: object
-    r51 :: bool
-    r52 :: object
-    r53 :: bool
-    r54 :: int
-    r55, r56 :: object
-    r57 :: bool
-    r58, r59 :: tuple[object, object, object]
-    r60, r61, r62 :: object
-    r63 :: object[4]
-    r64 :: object_ptr
-    r65 :: object
-    r66 :: i32
-    r67 :: bit
-    r68 :: bool
-    r69 :: bit
-    r70, r71, r72 :: tuple[object, object, object]
-    r73 :: object
-    r74 :: object[4]
-    r75 :: object_ptr
-    r76 :: object
-    r77 :: bit
-    r78 :: faster_eth_abi.utils.numeric.f_scale_places_obj
-    r79 :: bool
-    f :: object
-    r80 :: native_int
-    r81 :: bit
-    r82 :: native_int
-    r83, r84, r85 :: bit
-    r86, r87, r88, r89, r90 :: str
-    r91 :: int
-    r92, r93, places_repr, r94, r95, r96 :: str
-    r97 :: i32
-    r98 :: bit
-    r99 :: str
-    r100 :: i32
-    r101 :: bit
-    r102 :: object
-L0:
-    r0 = scale_places_env()
-    if is_error(r0) goto L62 (error at scale_places:91) else goto L1
-L1:
-    inc_ref places :: int
-    r1 = box(int, places)
-    r2 = PyLong_Check(r1)
-    dec_ref r1
-    if r2 goto L10 else goto L63 :: bool
-L2:
-    r3 = ''
-    r4 = 'Argument `places` must be int.  Got value '
-    r5 = '{:{}}'
-    inc_ref places :: int
-    r6 = box(int, places)
-    r7 = ''
-    r8 = 'format'
-    r9 = [r5, r6, r7]
-    r10 = load_address r9
-    r11 = PyObject_VectorcallMethod(r8, r10, 9223372036854775811, 0)
-    if is_error(r11) goto L64 (error at scale_places:98) else goto L3
-L3:
-    dec_ref r6
-    r12 = ' of type '
-    r13 = '{:{}}'
-    inc_ref places :: int
-    r14 = box(int, places)
-    r15 = CPy_TYPE(r14)
-    dec_ref r14
-    r16 = ''
-    r17 = 'format'
-    r18 = [r13, r15, r16]
-    r19 = load_address r18
-    r20 = PyObject_VectorcallMethod(r17, r19, 9223372036854775811, 0)
-    if is_error(r20) goto L65 (error at scale_places:99) else goto L4
-L4:
-    dec_ref r15
-    r21 = '.'
-    r22 = PyList_New(5)
-    if is_error(r22) goto L66 (error at scale_places:98) else goto L5
-L5:
-    r23 = get_element_ptr r22 ob_item :: PyListObject
-    r24 = load_mem r23 :: ptr*
-    inc_ref r4
-    set_mem r24, r4 :: builtins.object*
-    r25 = r24 + 8
-    set_mem r25, r11 :: builtins.object*
-    inc_ref r12
-    r26 = r24 + 16
-    set_mem r26, r12 :: builtins.object*
-    r27 = r24 + 24
-    set_mem r27, r20 :: builtins.object*
-    inc_ref r21
-    r28 = r24 + 32
-    set_mem r28, r21 :: builtins.object*
-    r29 = PyUnicode_Join(r3, r22)
-    dec_ref r22
-    if is_error(r29) goto L62 (error at scale_places:98) else goto L6
-L6:
-    r30 = builtins :: module
-    r31 = 'ValueError'
-    r32 = CPyObject_GetAttr(r30, r31)
-    if is_error(r32) goto L67 (error at scale_places:97) else goto L7
-L7:
-    r33 = [r29]
-    r34 = load_address r33
-    r35 = PyObject_Vectorcall(r32, r34, 1, 0)
-    dec_ref r32
-    if is_error(r35) goto L67 (error at scale_places:97) else goto L8
-L8:
-    dec_ref r29
-    CPy_Raise(r35)
-    dec_ref r35
-    if not 0 goto L62 (error at scale_places:97) else goto L9 :: bool
-L9:
-    unreachable
-L10:
-    r36 = faster_eth_abi.utils.numeric.abi_decimal_context :: static
-    if is_error(r36) goto L68 else goto L13
-L11:
-    r37 = raise NameError('value for final name "abi_decimal_context" was not set')
-    if not r37 goto L62 (error at scale_places:102) else goto L12 :: bool
-L12:
-    unreachable
-L13:
-    r38 = faster_eth_abi.utils.numeric.decimal_localcontext :: static
-    if is_error(r38) goto L69 else goto L16
-L14:
-    r39 = raise NameError('value for final name "decimal_localcontext" was not set')
-    if not r39 goto L62 (error at scale_places:102) else goto L15 :: bool
-L15:
-    unreachable
-L16:
-    r40 = [r36]
-    r41 = load_address r40
-    r42 = PyObject_Vectorcall(r38, r41, 1, 0)
-    if is_error(r42) goto L70 (error at scale_places:102) else goto L17
-L17:
-    r43 = CPy_TYPE(r42)
-    r44 = '__exit__'
-    r45 = CPyObject_GetAttr(r43, r44)
-    if is_error(r45) goto L71 (error at scale_places:102) else goto L18
-L18:
-    r46 = '__enter__'
-    r47 = CPyObject_GetAttr(r43, r46)
-    dec_ref r43
-    if is_error(r47) goto L72 (error at scale_places:102) else goto L19
-L19:
-    r48 = [r42]
-    r49 = load_address r48
-    r50 = PyObject_Vectorcall(r47, r49, 1, 0)
-    dec_ref r47
-    if is_error(r50) goto L72 (error at scale_places:102) else goto L73
-L20:
-    r51 = 1
-L21:
-    r52 = faster_eth_abi.utils.numeric.TEN :: static
-    if is_error(r52) goto L22 else goto L24
-L22:
-    r53 = raise NameError('value for final name "TEN" was not set')
-    if not r53 goto L26 (error at scale_places:103) else goto L74 :: bool
-L23:
-    unreachable
-L24:
-    r54 = CPyTagged_Negate(places)
-    r55 = box(int, r54)
-    r56 = CPyNumber_Power(r52, r55)
-    dec_ref r55
-    if is_error(r56) goto L26 (error at scale_places:103) else goto L25
-L25:
-    r0.scaling_factor = r56; r57 = is_error
-    if not r57 goto L26 (error at scale_places:103) else goto L34 :: bool
-L26:
-    r58 = CPy_CatchError()
-    r51 = 0
-    r59 = CPy_GetExcInfo()
-    r60 = r59[0]
-    r61 = r59[1]
-    r62 = r59[2]
-    dec_ref r59
-    r63 = [r42, r60, r61, r62]
-    r64 = load_address r63
-    r65 = PyObject_Vectorcall(r45, r64, 4, 0)
-    if is_error(r65) goto L75 (error at scale_places:102) else goto L27
-L27:
-    dec_ref r60
-    dec_ref r61
-    dec_ref r62
-    r66 = PyObject_IsTrue(r65)
-    dec_ref r65
-    r67 = r66 >= 0 :: signed
-    if not r67 goto L32 (error at scale_places:102) else goto L28 :: bool
-L28:
-    r68 = truncate r66: i32 to builtins.bool
-    if r68 goto L31 else goto L29 :: bool
-L29:
-    CPy_Reraise()
-    if not 0 goto L32 else goto L76 :: bool
-L30:
-    unreachable
-L31:
-    CPy_RestoreExcInfo(r58)
-    dec_ref r58
-    goto L34
-L32:
-    CPy_RestoreExcInfo(r58)
-    dec_ref r58
-    r69 = CPy_KeepPropagating()
-    if not r69 goto L35 else goto L77 :: bool
-L33:
-    unreachable
-L34:
-    r70 = <error> :: tuple[object, object, object]
-    r71 = r70
-    goto L36
-L35:
-    r72 = CPy_CatchError()
-    r71 = r72
-L36:
-    if r51 goto L37 else goto L78 :: bool
-L37:
-    r73 = load_address _Py_NoneStruct
-    r74 = [r42, r73, r73, r73]
-    r75 = load_address r74
-    r76 = PyObject_Vectorcall(r45, r75, 4, 0)
-    dec_ref r45
-    if is_error(r76) goto L79 (error at scale_places:102) else goto L80
-L38:
-    dec_ref r42
-L39:
-    if is_error(r71) goto L46 else goto L81
-L40:
-    CPy_Reraise()
-    if not 0 goto L42 else goto L82 :: bool
-L41:
-    unreachable
-L42:
-    if is_error(r71) goto L44 else goto L43
-L43:
-    CPy_RestoreExcInfo(r71)
-    xdec_ref r71
-L44:
-    r77 = CPy_KeepPropagating()
-    if not r77 goto L62 else goto L45 :: bool
-L45:
-    unreachable
-L46:
-    r78 = f_scale_places_obj()
-    if is_error(r78) goto L70 (error at scale_places:105) else goto L47
-L47:
-    r78.__mypyc_env__ = r0; r79 = is_error
-    if not r79 goto L83 (error at scale_places:105) else goto L48 :: bool
-L48:
-    f = r78
-    r80 = places & 1
-    r81 = r80 != 0
-    if r81 goto L50 else goto L49 :: bool
-L49:
-    r82 = 0 & 1
-    r83 = r82 != 0
-    if r83 goto L50 else goto L51 :: bool
-L50:
-    r84 = CPyTagged_IsLt_(0, places)
-    if r84 goto L52 else goto L55 :: bool
-L51:
-    r85 = places > 0 :: signed
-    if r85 goto L52 else goto L55 :: bool
-L52:
-    r86 = 'Eneg'
-    r87 = CPyTagged_Str(places)
-    if is_error(r87) goto L84 (error at scale_places:109) else goto L53
-L53:
-    r88 = CPyStr_Build(2, r86, r87)
-    dec_ref r87
-    if is_error(r88) goto L84 (error at scale_places:109) else goto L54
-L54:
-    r89 = r88
-    goto L58
-L55:
-    r90 = 'Epos'
-    r91 = CPyTagged_Negate(places)
-    r92 = CPyTagged_Str(r91)
-    dec_ref r91 :: int
-    if is_error(r92) goto L84 (error at scale_places:109) else goto L56
-L56:
-    r93 = CPyStr_Build(2, r90, r92)
-    dec_ref r92
-    if is_error(r93) goto L84 (error at scale_places:109) else goto L57
-L57:
-    r89 = r93
-L58:
-    places_repr = r89
-    r94 = 'scale_by_'
-    r95 = CPyStr_Build(2, r94, places_repr)
-    dec_ref places_repr
-    if is_error(r95) goto L84 (error at scale_places:110) else goto L59
-L59:
-    r96 = '__name__'
-    r97 = PyObject_SetAttr(f, r96, r95)
-    r98 = r97 >= 0 :: signed
-    if not r98 goto L85 (error at scale_places:112) else goto L60 :: bool
-L60:
-    r99 = '__qualname__'
-    r100 = PyObject_SetAttr(f, r99, r95)
-    dec_ref r95
-    r101 = r100 >= 0 :: signed
-    if not r101 goto L84 (error at scale_places:113) else goto L61 :: bool
-L61:
-    return f
-L62:
-    r102 = <error> :: object
-    return r102
-L63:
-    dec_ref r0
-    goto L2
-L64:
-    dec_ref r6
-    goto L62
-L65:
-    dec_ref r11
-    dec_ref r15
-    goto L62
-L66:
-    dec_ref r11
-    dec_ref r20
-    goto L62
-L67:
-    dec_ref r29
-    goto L62
-L68:
-    dec_ref r0
-    goto L11
-L69:
-    dec_ref r0
-    goto L14
-L70:
-    dec_ref r0
-    goto L62
-L71:
-    dec_ref r0
-    dec_ref r42
-    dec_ref r43
-    goto L62
-L72:
-    dec_ref r0
-    dec_ref r42
-    dec_ref r45
-    goto L62
-L73:
-    dec_ref r50
-    goto L20
-L74:
-    dec_ref r0
-    dec_ref r42
-    dec_ref r45
-    goto L23
-L75:
-    dec_ref r60
-    dec_ref r61
-    dec_ref r62
-    goto L32
-L76:
-    dec_ref r0
-    dec_ref r42
-    dec_ref r45
-    dec_ref r58
-    goto L30
-L77:
-    dec_ref r0
-    dec_ref r42
-    dec_ref r45
-    goto L33
-L78:
-    dec_ref r42
-    dec_ref r45
-    goto L39
-L79:
-    dec_ref r0
-    dec_ref r42
-    goto L42
-L80:
-    dec_ref r76
-    goto L38
-L81:
-    dec_ref r0
-    goto L40
-L82:
-    xdec_ref r71
-    goto L41
-L83:
-    dec_ref r78
-    goto L62
-L84:
-    dec_ref f
-    goto L62
-L85:
-    dec_ref f
-    dec_ref r95
-    goto L62
-
-def __top_level__():
-    r0, r1 :: object
-    r2 :: bit
-    r3 :: str
-    r4 :: object
-    r5 :: object_ptr
-    r6 :: object_ptr[1]
-    r7 :: c_ptr
-    r8 :: native_int[1]
-    r9 :: c_ptr
-    r10 :: object
-    r11 :: dict
-    r12, r13 :: str
-    r14 :: bit
-    r15 :: object
-    r16 :: str
-    r17 :: dict
-    r18 :: object
-    r19 :: dict
-    r20 :: str
-    r21 :: object
-    r22 :: i32
-    r23 :: bit
-    r24 :: object
-    r25 :: str
-    r26, r27 :: object
-    r28 :: object[1]
-    r29 :: object_ptr
-    r30, r31 :: object
-    r32 :: dict
-    r33 :: str
-    r34 :: i32
-    r35 :: bit
-    r36 :: object
-    r37 :: str
-    r38 :: object
-    r39 :: dict
-    r40 :: str
-    r41 :: i32
-    r42 :: bit
-    r43 :: object
-    r44 :: str
-    r45, r46 :: object
-    r47 :: object[1]
-    r48 :: object_ptr
-    r49 :: object
-    r50 :: dict
-    r51 :: str
-    r52 :: i32
-    r53 :: bit
-    r54 :: object
-    r55 :: str
-    r56, r57 :: object
-    r58 :: object[1]
-    r59 :: object_ptr
-    r60 :: object
-    r61 :: dict
-    r62 :: str
-    r63 :: i32
-    r64 :: bit
-    r65 :: object
-    r66 :: str
-    r67 :: object
-    r68 :: dict
-    r69 :: str
-    r70 :: i32
-    r71 :: bit
-    r72, r73 :: dict
-    r74 :: str
-    r75 :: i32
-    r76 :: bit
-    r77, r78 :: dict
-    r79 :: str
-    r80 :: i32
-    r81 :: bit
-    r82, r83 :: dict
-    r84 :: str
-    r85 :: i32
-    r86 :: bit
-    r87, r88 :: dict
-    r89 :: str
-    r90 :: i32
-    r91 :: bit
-    r92 :: None
-L0:
-    r0 = builtins :: module
-    r1 = load_address _Py_NoneStruct
-    r2 = r0 != r1
-    if r2 goto L3 else goto L1 :: bool
-L1:
-    r3 = 'builtins'
-    r4 = PyImport_Import(r3)
-    if is_error(r4) goto L28 (error at <module>:-1) else goto L2
-L2:
-    builtins = r4 :: module
-    dec_ref r4
-L3:
-    r5 = load_address decimal :: module
-    r6 = [r5]
-    r7 = load_address r6
-    r8 = [1]
-    r9 = load_address r8
-    r10 = (('decimal', 'decimal', 'decimal'),)
-    r11 = faster_eth_abi.utils.numeric.globals :: static
-    r12 = 'faster_eth_abi/utils/numeric.py'
-    r13 = '<module>'
-    r14 = CPyImport_ImportMany(r10, r7, r11, r12, r13, r9)
-    if not r14 goto L28 else goto L4 :: bool
-L4:
-    r15 = ('Callable', 'Dict', 'Final', 'Tuple')
-    r16 = 'typing'
-    r17 = faster_eth_abi.utils.numeric.globals :: static
-    r18 = CPyImport_ImportFromMany(r16, r15, r15, r17)
-    if is_error(r18) goto L28 (error at <module>:2) else goto L5
-L5:
-    typing = r18 :: module
-    dec_ref r18
-    r19 = faster_eth_abi.utils.numeric.globals :: static
-    r20 = 'ABI_DECIMAL_PREC'
-    r21 = object 999
-    r22 = CPyDict_SetItem(r19, r20, r21)
-    r23 = r22 >= 0 :: signed
-    if not r23 goto L28 (error at <module>:9) else goto L6 :: bool
-L6:
-    r24 = decimal :: module
-    r25 = 'Context'
-    r26 = CPyObject_GetAttr(r24, r25)
-    if is_error(r26) goto L28 (error at <module>:11) else goto L7
-L7:
-    r27 = object 999
-    r28 = [r27]
-    r29 = load_address r28
-    r30 = ('prec',)
-    r31 = PyObject_Vectorcall(r26, r29, 0, r30)
-    dec_ref r26
-    if is_error(r31) goto L28 (error at <module>:11) else goto L8
-L8:
-    faster_eth_abi.utils.numeric.abi_decimal_context = r31 :: static
-    r32 = faster_eth_abi.utils.numeric.globals :: static
-    r33 = 'abi_decimal_context'
-    r34 = CPyDict_SetItem(r32, r33, r31)
-    dec_ref r31
-    r35 = r34 >= 0 :: signed
-    if not r35 goto L28 (error at <module>:11) else goto L9 :: bool
-L9:
-    r36 = decimal :: module
-    r37 = 'localcontext'
-    r38 = CPyObject_GetAttr(r36, r37)
-    if is_error(r38) goto L28 (error at <module>:12) else goto L10
-L10:
-    faster_eth_abi.utils.numeric.decimal_localcontext = r38 :: static
-    r39 = faster_eth_abi.utils.numeric.globals :: static
-    r40 = 'decimal_localcontext'
-    r41 = CPyDict_SetItem(r39, r40, r38)
-    dec_ref r38
-    r42 = r41 >= 0 :: signed
-    if not r42 goto L28 (error at <module>:12) else goto L11 :: bool
-L11:
-    r43 = decimal :: module
-    r44 = 'Decimal'
-    r45 = CPyObject_GetAttr(r43, r44)
-    if is_error(r45) goto L28 (error at <module>:14) else goto L12
-L12:
-    r46 = object 0
-    r47 = [r46]
-    r48 = load_address r47
-    r49 = PyObject_Vectorcall(r45, r48, 1, 0)
-    dec_ref r45
-    if is_error(r49) goto L28 (error at <module>:14) else goto L13
-L13:
-    faster_eth_abi.utils.numeric.ZERO = r49 :: static
-    r50 = faster_eth_abi.utils.numeric.globals :: static
-    r51 = 'ZERO'
-    r52 = CPyDict_SetItem(r50, r51, r49)
-    dec_ref r49
-    r53 = r52 >= 0 :: signed
-    if not r53 goto L28 (error at <module>:14) else goto L14 :: bool
-L14:
-    r54 = decimal :: module
-    r55 = 'Decimal'
-    r56 = CPyObject_GetAttr(r54, r55)
-    if is_error(r56) goto L28 (error at <module>:15) else goto L15
-L15:
-    r57 = object 10
-    r58 = [r57]
-    r59 = load_address r58
-    r60 = PyObject_Vectorcall(r56, r59, 1, 0)
-    dec_ref r56
-    if is_error(r60) goto L28 (error at <module>:15) else goto L16
-L16:
-    faster_eth_abi.utils.numeric.TEN = r60 :: static
-    r61 = faster_eth_abi.utils.numeric.globals :: static
-    r62 = 'TEN'
-    r63 = CPyDict_SetItem(r61, r62, r60)
-    dec_ref r60
-    r64 = r63 >= 0 :: signed
-    if not r64 goto L28 (error at <module>:15) else goto L17 :: bool
-L17:
-    r65 = decimal :: module
-    r66 = 'Decimal'
-    r67 = CPyObject_GetAttr(r65, r66)
-    if is_error(r67) goto L28 (error at <module>:17) else goto L18
-L18:
-    faster_eth_abi.utils.numeric.Decimal = r67 :: static
-    r68 = faster_eth_abi.utils.numeric.globals :: static
-    r69 = 'Decimal'
-    r70 = CPyDict_SetItem(r68, r69, r67)
-    dec_ref r67
-    r71 = r70 >= 0 :: signed
-    if not r71 goto L28 (error at <module>:17) else goto L19 :: bool
-L19:
-    r72 = PyDict_New()
-    if is_error(r72) goto L28 (error at <module>:25) else goto L20
-L20:
-    faster_eth_abi.utils.numeric._unsigned_integer_bounds_cache = r72 :: static
-    r73 = faster_eth_abi.utils.numeric.globals :: static
-    r74 = '_unsigned_integer_bounds_cache'
-    r75 = CPyDict_SetItem(r73, r74, r72)
-    dec_ref r72
-    r76 = r75 >= 0 :: signed
-    if not r76 goto L28 (error at <module>:25) else goto L21 :: bool
-L21:
-    r77 = PyDict_New()
-    if is_error(r77) goto L28 (error at <module>:36) else goto L22
-L22:
-    faster_eth_abi.utils.numeric._signed_integer_bounds_cache = r77 :: static
-    r78 = faster_eth_abi.utils.numeric.globals :: static
-    r79 = '_signed_integer_bounds_cache'
-    r80 = CPyDict_SetItem(r78, r79, r77)
-    dec_ref r77
-    r81 = r80 >= 0 :: signed
-    if not r81 goto L28 (error at <module>:36) else goto L23 :: bool
-L23:
-    r82 = PyDict_New()
-    if is_error(r82) goto L28 (error at <module>:50) else goto L24
-L24:
-    faster_eth_abi.utils.numeric._unsigned_fixed_bounds_cache = r82 :: static
-    r83 = faster_eth_abi.utils.numeric.globals :: static
-    r84 = '_unsigned_fixed_bounds_cache'
-    r85 = CPyDict_SetItem(r83, r84, r82)
-    dec_ref r82
-    r86 = r85 >= 0 :: signed
-    if not r86 goto L28 (error at <module>:50) else goto L25 :: bool
-L25:
-    r87 = PyDict_New()
-    if is_error(r87) goto L28 (error at <module>:69) else goto L26
-L26:
-    faster_eth_abi.utils.numeric._signed_fixed_bounds_cache = r87 :: static
-    r88 = faster_eth_abi.utils.numeric.globals :: static
-    r89 = '_signed_fixed_bounds_cache'
-    r90 = CPyDict_SetItem(r88, r89, r87)
-    dec_ref r87
-    r91 = r90 >= 0 :: signed
-    if not r91 goto L28 (error at <module>:69) else goto L27 :: bool
-L27:
-    return 1
-L28:
-    r92 = <error> :: None
-    return r92
-
-def zpad(value, length):
-    value :: bytes
-    length :: int
-    r0 :: bytes
-    r1 :: str
-    r2 :: object
-    r3 :: object[3]
-    r4 :: object_ptr
-    r5 :: object
-    r6, r7 :: bytes
-L0:
-    r0 = b'\x00'
-    r1 = 'rjust'
-    inc_ref length :: int
-    r2 = box(int, length)
-    r3 = [value, r2, r0]
-    r4 = load_address r3
-    r5 = PyObject_VectorcallMethod(r1, r4, 9223372036854775811, 0)
-    if is_error(r5) goto L4 (error at zpad:2) else goto L1
-L1:
-    dec_ref r2
-    r6 = cast(bytes, r5)
-    if is_error(r6) goto L3 (error at zpad:2) else goto L2
-L2:
-    return r6
-L3:
-    r7 = <error> :: bytes
-    return r7
-L4:
-    dec_ref r2
-    goto L3
-
-def zpad32(value):
-    value, r0, r1 :: bytes
-L0:
-    r0 = zpad(value, 64)
-    if is_error(r0) goto L2 (error at zpad32:6) else goto L1
-L1:
-    return r0
-L2:
-    r1 = <error> :: bytes
-    return r1
-
-def zpad_right(value, length):
-    value :: bytes
-    length :: int
-    r0 :: bytes
-    r1 :: str
-    r2 :: object
-    r3 :: object[3]
-    r4 :: object_ptr
-    r5 :: object
-    r6, r7 :: bytes
-L0:
-    r0 = b'\x00'
-    r1 = 'ljust'
-    inc_ref length :: int
-    r2 = box(int, length)
-    r3 = [value, r2, r0]
-    r4 = load_address r3
-    r5 = PyObject_VectorcallMethod(r1, r4, 9223372036854775811, 0)
-    if is_error(r5) goto L4 (error at zpad_right:10) else goto L1
-L1:
-    dec_ref r2
-    r6 = cast(bytes, r5)
-    if is_error(r6) goto L3 (error at zpad_right:10) else goto L2
-L2:
-    return r6
-L3:
-    r7 = <error> :: bytes
-    return r7
-L4:
-    dec_ref r2
-    goto L3
-
-def zpad32_right(value):
-    value, r0, r1 :: bytes
-L0:
-    r0 = zpad_right(value, 64)
-    if is_error(r0) goto L2 (error at zpad32_right:14) else goto L1
-L1:
-    return r0
-L2:
-    r1 = <error> :: bytes
-    return r1
-
-def fpad(value, length):
-    value :: bytes
-    length :: int
-    r0 :: bytes
-    r1 :: str
-    r2 :: object
-    r3 :: object[3]
-    r4 :: object_ptr
-    r5 :: object
-    r6, r7 :: bytes
-L0:
-    r0 = b'\xff'
-    r1 = 'rjust'
-    inc_ref length :: int
-    r2 = box(int, length)
-    r3 = [value, r2, r0]
-    r4 = load_address r3
-    r5 = PyObject_VectorcallMethod(r1, r4, 9223372036854775811, 0)
-    if is_error(r5) goto L4 (error at fpad:18) else goto L1
-L1:
-    dec_ref r2
-    r6 = cast(bytes, r5)
-    if is_error(r6) goto L3 (error at fpad:18) else goto L2
-L2:
-    return r6
-L3:
-    r7 = <error> :: bytes
-    return r7
-L4:
-    dec_ref r2
-    goto L3
-
-def fpad32(value):
-    value, r0, r1 :: bytes
-L0:
-    r0 = fpad(value, 64)
-    if is_error(r0) goto L2 (error at fpad32:22) else goto L1
-L1:
-    return r0
-L2:
-    r1 = <error> :: bytes
-    return r1
-
-def __top_level__():
-    r0, r1 :: object
-    r2 :: bit
-    r3 :: str
-    r4 :: object
-    r5 :: None
-L0:
-    r0 = builtins :: module
-    r1 = load_address _Py_NoneStruct
-    r2 = r0 != r1
-    if r2 goto L3 else goto L1 :: bool
-L1:
-    r3 = 'builtins'
-    r4 = PyImport_Import(r3)
-    if is_error(r4) goto L4 (error at <module>:-1) else goto L2
-L2:
-    builtins = r4 :: module
-    dec_ref r4
-L3:
-    return 1
-L4:
-    r5 = <error> :: None
-    return r5
-
-def encode_c(self, types, args):
-    self, types, args :: object
-    r0 :: str
-    r1 :: None
-    r2 :: str
-    r3 :: None
-    r4 :: str
-    r5 :: object
-    r6 :: str
-    r7 :: object
-    r8 :: tuple
-    r9 :: object
-    r10 :: object[1]
-    r11 :: object_ptr
-    r12 :: object
-    r13, r14 :: bytes
-L0:
-    r0 = 'types'
-    r1 = validate_list_like_param(types, r0)
-    if is_error(r1) goto L9 (error at encode_c:43) else goto L1
-L1:
-    r2 = 'args'
-    r3 = validate_list_like_param(args, r2)
-    if is_error(r3) goto L9 (error at encode_c:44) else goto L2
-L2:
-    r4 = '_registry'
-    r5 = CPyObject_GetAttr(self, r4)
-    if is_error(r5) goto L9 (error at encode_c:46) else goto L3
-L3:
-    r6 = 'get_tuple_encoder'
-    r7 = CPyObject_GetAttr(r5, r6)
-    dec_ref r5
-    if is_error(r7) goto L9 (error at encode_c:46) else goto L4
-L4:
-    r8 = PySequence_Tuple(types)
-    if is_error(r8) goto L10 (error at encode_c:46) else goto L5
-L5:
-    r9 = PyObject_CallObject(r7, r8)
-    dec_ref r7
-    dec_ref r8
-    if is_error(r9) goto L9 (error at encode_c:46) else goto L6
-L6:
-    r10 = [args]
-    r11 = load_address r10
-    r12 = PyObject_Vectorcall(r9, r11, 1, 0)
-    dec_ref r9
-    if is_error(r12) goto L9 (error at encode_c:48) else goto L7
-L7:
-    r13 = cast(bytes, r12)
-    if is_error(r13) goto L9 (error at encode_c:48) else goto L8
-L8:
-    return r13
-L9:
-    r14 = <error> :: bytes
-    return r14
-L10:
-    dec_ref r7
-    goto L9
-
-def decode_c(self, types, data, strict):
-    self, types :: object
-    data :: union[bytes, object]
-    strict :: bool
-    r0 :: str
-    r1 :: None
-    r2 :: str
-    r3 :: None
-    r4 :: str
-    r5 :: object
-    r6 :: str
-    r7 :: object
-    r8 :: list
-    r9 :: object
-    r10 :: str
-    r11 :: tuple
-    r12 :: object
-    r13 :: dict
-    r14 :: object
-    r15 :: str
-    r16 :: object[2]
-    r17 :: object_ptr
-    r18 :: object
-    r19 :: object[1]
-    r20 :: object_ptr
-    r21 :: object
-    r22, r23 :: tuple
-L0:
-    if is_error(strict) goto L1 else goto L2
-L1:
-    strict = 1
-L2:
-    r0 = 'types'
-    r1 = validate_list_like_param(types, r0)
-    if is_error(r1) goto L15 (error at decode_c:75) else goto L3
-L3:
-    r2 = 'data'
-    r3 = validate_bytes_param(data, r2)
-    if is_error(r3) goto L15 (error at decode_c:76) else goto L4
-L4:
-    r4 = '_registry'
-    r5 = CPyObject_GetAttr(self, r4)
-    if is_error(r5) goto L15 (error at decode_c:78) else goto L5
-L5:
-    r6 = 'get_tuple_decoder'
-    r7 = CPyObject_GetAttr(r5, r6)
-    dec_ref r5
-    if is_error(r7) goto L15 (error at decode_c:78) else goto L6
-L6:
-    r8 = PyList_New(0)
-    if is_error(r8) goto L16 (error at decode_c:78) else goto L7
-L7:
-    r9 = CPyList_Extend(r8, types)
-    if is_error(r9) goto L17 (error at decode_c:78) else goto L18
-L8:
-    r10 = 'strict'
-    r11 = PyList_AsTuple(r8)
-    dec_ref r8
-    if is_error(r11) goto L16 (error at decode_c:78) else goto L9
-L9:
-    r12 = box(bool, strict)
-    r13 = CPyDict_Build(1, r10, r12)
-    if is_error(r13) goto L19 (error at decode_c:78) else goto L10
-L10:
-    r14 = PyObject_Call(r7, r11, r13)
-    dec_ref r7
-    dec_ref r11
-    dec_ref r13
-    if is_error(r14) goto L15 (error at decode_c:78) else goto L11
-L11:
-    r15 = 'stream_class'
-    r16 = [self, data]
-    r17 = load_address r16
-    r18 = PyObject_VectorcallMethod(r15, r17, 9223372036854775810, 0)
-    if is_error(r18) goto L20 (error at decode_c:79) else goto L12
-L12:
-    r19 = [r18]
-    r20 = load_address r19
-    r21 = PyObject_Vectorcall(r14, r20, 1, 0)
-    dec_ref r14
-    if is_error(r21) goto L21 (error at decode_c:81) else goto L13
-L13:
-    dec_ref r18
-    r22 = cast(tuple, r21)
-    if is_error(r22) goto L15 (error at decode_c:81) else goto L14
-L14:
-    return r22
-L15:
-    r23 = <error> :: tuple
-    return r23
-L16:
-    dec_ref r7
-    goto L15
-L17:
-    dec_ref r7
-    dec_ref r8
-    goto L15
-L18:
-    dec_ref r9
-    goto L8
-L19:
-    dec_ref r7
-    dec_ref r11
-    goto L15
-L20:
-    dec_ref r14
-    goto L15
-L21:
-    dec_ref r18
-    goto L15
-
-def __top_level__():
-    r0, r1 :: object
-    r2 :: bit
-    r3 :: str
-    r4, r5 :: object
-    r6 :: str
-    r7 :: dict
-    r8, r9 :: object
-    r10 :: str
-    r11 :: dict
-    r12, r13 :: object
-    r14 :: str
-    r15 :: dict
-    r16 :: object
-    r17 :: None
-L0:
-    r0 = builtins :: module
-    r1 = load_address _Py_NoneStruct
-    r2 = r0 != r1
-    if r2 goto L3 else goto L1 :: bool
-L1:
-    r3 = 'builtins'
-    r4 = PyImport_Import(r3)
-    if is_error(r4) goto L8 (error at <module>:-1) else goto L2
-L2:
-    builtins = r4 :: module
-    dec_ref r4
-L3:
-    r5 = ('TYPE_CHECKING', 'Any', 'Iterable', 'Tuple')
-    r6 = 'typing'
-    r7 = faster_eth_abi._codec.globals :: static
-    r8 = CPyImport_ImportFromMany(r6, r5, r5, r7)
-    if is_error(r8) goto L8 (error at <module>:1) else goto L4
-L4:
-    typing = r8 :: module
-    dec_ref r8
-    r9 = ('Decodable', 'TypeStr')
-    r10 = 'eth_typing'
-    r11 = faster_eth_abi._codec.globals :: static
-    r12 = CPyImport_ImportFromMany(r10, r9, r9, r11)
-    if is_error(r12) goto L8 (error at <module>:8) else goto L5
-L5:
-    eth_typing = r12 :: module
-    dec_ref r12
-    r13 = ('validate_bytes_param', 'validate_list_like_param')
-    r14 = 'faster_eth_abi.utils.validation'
-    r15 = faster_eth_abi._codec.globals :: static
-    r16 = CPyImport_ImportFromMany(r14, r13, r13, r15)
-    if is_error(r16) goto L8 (error at <module>:13) else goto L6
-L6:
-    faster_eth_abi.utils.validation = r16 :: module
-    dec_ref r16
-    if 0 goto L7 else goto L7 :: bool
-L7:
-    return 1
-L8:
-    r17 = <error> :: None
-    return r17
-
 def validate_bytes_param(param, param_name):
     param :: object
     param_name :: str
@@ -4766,6 +2200,3090 @@ L5:
     r9 = <error> :: None
     return r9
 
+def ceil32(x):
+    x, r0 :: int
+    r1 :: bit
+    r2, r3, r4, r5, r6 :: int
+L0:
+    r0 = CPyTagged_Remainder(x, 64)
+    if is_error(r0) goto L6 (error at ceil32:20) else goto L1
+L1:
+    r1 = r0 == 0
+    dec_ref r0 :: int
+    if r1 goto L2 else goto L3 :: bool
+L2:
+    inc_ref x :: int
+    r2 = x
+    goto L5
+L3:
+    r3 = CPyTagged_Add(x, 64)
+    r4 = CPyTagged_Remainder(x, 64)
+    if is_error(r4) goto L7 (error at ceil32:21) else goto L4
+L4:
+    r5 = CPyTagged_Subtract(r3, r4)
+    dec_ref r3 :: int
+    dec_ref r4 :: int
+    r2 = r5
+L5:
+    return r2
+L6:
+    r6 = <error> :: int
+    return r6
+L7:
+    dec_ref r3 :: int
+    goto L6
+
+def compute_unsigned_integer_bounds(num_bits):
+    num_bits :: int
+    r0 :: dict
+    r1 :: bool
+    r2, r3 :: object
+    r4, bounds :: union[tuple[int, int], None]
+    r5 :: object
+    r6 :: bit
+    r7, r8, r9, r10, r11 :: object
+    r12 :: tuple[int, object]
+    r13 :: object
+    r14 :: tuple[int, int]
+    r15 :: dict
+    r16 :: bool
+    r17, r18 :: object
+    r19 :: i32
+    r20 :: bit
+    r21, r22 :: tuple[int, int]
+L0:
+    r0 = faster_eth_abi.utils.numeric._unsigned_integer_bounds_cache :: static
+    if is_error(r0) goto L1 else goto L3
+L1:
+    r1 = raise NameError('value for final name "_unsigned_integer_bounds_cache" was not set')
+    if not r1 goto L15 (error at compute_unsigned_integer_bounds:28) else goto L2 :: bool
+L2:
+    unreachable
+L3:
+    inc_ref num_bits :: int
+    r2 = box(int, num_bits)
+    r3 = CPyDict_GetWithNone(r0, r2)
+    dec_ref r2
+    if is_error(r3) goto L15 (error at compute_unsigned_integer_bounds:28) else goto L4
+L4:
+    r4 = cast(union[tuple[int, int], None], r3)
+    if is_error(r4) goto L15 (error at compute_unsigned_integer_bounds:28) else goto L5
+L5:
+    bounds = r4
+    r5 = load_address _Py_NoneStruct
+    r6 = bounds == r5
+    if r6 goto L16 else goto L13 :: bool
+L6:
+    r7 = object 2
+    inc_ref num_bits :: int
+    r8 = box(int, num_bits)
+    r9 = CPyNumber_Power(r7, r8)
+    dec_ref r8
+    if is_error(r9) goto L15 (error at compute_unsigned_integer_bounds:30) else goto L7
+L7:
+    r10 = object 1
+    r11 = PyNumber_Subtract(r9, r10)
+    dec_ref r9
+    if is_error(r11) goto L15 (error at compute_unsigned_integer_bounds:30) else goto L8
+L8:
+    r12 = (0, r11)
+    r13 = box(tuple[int, object], r12)
+    bounds = r13
+    r14 = unbox(tuple[int, int], bounds)
+    if is_error(r14) goto L17 (error at compute_unsigned_integer_bounds:31) else goto L9
+L9:
+    r15 = faster_eth_abi.utils.numeric._unsigned_integer_bounds_cache :: static
+    if is_error(r15) goto L18 else goto L12
+L10:
+    r16 = raise NameError('value for final name "_unsigned_integer_bounds_cache" was not set')
+    if not r16 goto L15 (error at compute_unsigned_integer_bounds:31) else goto L11 :: bool
+L11:
+    unreachable
+L12:
+    inc_ref num_bits :: int
+    r17 = box(int, num_bits)
+    r18 = box(tuple[int, int], r14)
+    r19 = CPyDict_SetItem(r15, r17, r18)
+    dec_ref r17
+    dec_ref r18
+    r20 = r19 >= 0 :: signed
+    if not r20 goto L17 (error at compute_unsigned_integer_bounds:31) else goto L13 :: bool
+L13:
+    r21 = unbox(tuple[int, int], bounds)
+    dec_ref bounds
+    if is_error(r21) goto L15 (error at compute_unsigned_integer_bounds:32) else goto L14
+L14:
+    return r21
+L15:
+    r22 = <error> :: tuple[int, int]
+    return r22
+L16:
+    dec_ref bounds
+    goto L6
+L17:
+    dec_ref bounds
+    goto L15
+L18:
+    dec_ref bounds
+    dec_ref r14
+    goto L10
+
+def compute_signed_integer_bounds(num_bits):
+    num_bits :: int
+    r0 :: dict
+    r1 :: bool
+    r2, r3 :: object
+    r4, bounds :: union[tuple[int, int], None]
+    r5 :: object
+    r6 :: bit
+    r7 :: int
+    r8, r9, r10, r11, r12 :: object
+    r13 :: int
+    r14, r15, r16, r17, r18 :: object
+    r19 :: tuple[object, object]
+    r20 :: object
+    r21 :: tuple[int, int]
+    r22 :: dict
+    r23 :: bool
+    r24, r25 :: object
+    r26 :: i32
+    r27 :: bit
+    r28, r29 :: tuple[int, int]
+L0:
+    r0 = faster_eth_abi.utils.numeric._signed_integer_bounds_cache :: static
+    if is_error(r0) goto L1 else goto L3
+L1:
+    r1 = raise NameError('value for final name "_signed_integer_bounds_cache" was not set')
+    if not r1 goto L17 (error at compute_signed_integer_bounds:39) else goto L2 :: bool
+L2:
+    unreachable
+L3:
+    inc_ref num_bits :: int
+    r2 = box(int, num_bits)
+    r3 = CPyDict_GetWithNone(r0, r2)
+    dec_ref r2
+    if is_error(r3) goto L17 (error at compute_signed_integer_bounds:39) else goto L4
+L4:
+    r4 = cast(union[tuple[int, int], None], r3)
+    if is_error(r4) goto L17 (error at compute_signed_integer_bounds:39) else goto L5
+L5:
+    bounds = r4
+    r5 = load_address _Py_NoneStruct
+    r6 = bounds == r5
+    if r6 goto L18 else goto L15 :: bool
+L6:
+    r7 = CPyTagged_Subtract(num_bits, 2)
+    r8 = object 2
+    r9 = box(int, r7)
+    r10 = CPyNumber_Power(r8, r9)
+    dec_ref r9
+    if is_error(r10) goto L17 (error at compute_signed_integer_bounds:42) else goto L7
+L7:
+    r11 = object -1
+    r12 = PyNumber_Multiply(r11, r10)
+    dec_ref r10
+    if is_error(r12) goto L17 (error at compute_signed_integer_bounds:42) else goto L8
+L8:
+    r13 = CPyTagged_Subtract(num_bits, 2)
+    r14 = object 2
+    r15 = box(int, r13)
+    r16 = CPyNumber_Power(r14, r15)
+    dec_ref r15
+    if is_error(r16) goto L19 (error at compute_signed_integer_bounds:43) else goto L9
+L9:
+    r17 = object 1
+    r18 = PyNumber_Subtract(r16, r17)
+    dec_ref r16
+    if is_error(r18) goto L19 (error at compute_signed_integer_bounds:43) else goto L10
+L10:
+    r19 = (r12, r18)
+    r20 = box(tuple[object, object], r19)
+    bounds = r20
+    r21 = unbox(tuple[int, int], bounds)
+    if is_error(r21) goto L20 (error at compute_signed_integer_bounds:45) else goto L11
+L11:
+    r22 = faster_eth_abi.utils.numeric._signed_integer_bounds_cache :: static
+    if is_error(r22) goto L21 else goto L14
+L12:
+    r23 = raise NameError('value for final name "_signed_integer_bounds_cache" was not set')
+    if not r23 goto L17 (error at compute_signed_integer_bounds:45) else goto L13 :: bool
+L13:
+    unreachable
+L14:
+    inc_ref num_bits :: int
+    r24 = box(int, num_bits)
+    r25 = box(tuple[int, int], r21)
+    r26 = CPyDict_SetItem(r22, r24, r25)
+    dec_ref r24
+    dec_ref r25
+    r27 = r26 >= 0 :: signed
+    if not r27 goto L20 (error at compute_signed_integer_bounds:45) else goto L15 :: bool
+L15:
+    r28 = unbox(tuple[int, int], bounds)
+    dec_ref bounds
+    if is_error(r28) goto L17 (error at compute_signed_integer_bounds:46) else goto L16
+L16:
+    return r28
+L17:
+    r29 = <error> :: tuple[int, int]
+    return r29
+L18:
+    dec_ref bounds
+    goto L6
+L19:
+    dec_ref r12
+    goto L17
+L20:
+    dec_ref bounds
+    goto L17
+L21:
+    dec_ref bounds
+    dec_ref r21
+    goto L12
+
+def compute_unsigned_fixed_bounds(num_bits, frac_places):
+    num_bits, frac_places :: int
+    r0 :: dict
+    r1 :: bool
+    r2 :: tuple[int, int]
+    r3, r4 :: object
+    upper :: union[object, None]
+    r5 :: object
+    r6 :: bit
+    r7 :: tuple[int, int]
+    r8 :: int
+    r9 :: object
+    r10 :: bool
+    r11 :: object
+    r12 :: str
+    r13 :: object
+    r14 :: object[1]
+    r15 :: object_ptr
+    r16, r17 :: object
+    r18 :: str
+    r19 :: object
+    r20 :: str
+    r21 :: object
+    r22 :: object[1]
+    r23 :: object_ptr
+    r24 :: object
+    r25 :: bool
+    r26 :: object
+    r27 :: bool
+    r28 :: object
+    r29 :: object[1]
+    r30 :: object_ptr
+    r31, r32 :: object
+    r33 :: bool
+    r34 :: int
+    r35, r36, r37 :: object
+    r38, r39 :: tuple[object, object, object]
+    r40, r41, r42 :: object
+    r43 :: object[4]
+    r44 :: object_ptr
+    r45 :: object
+    r46 :: i32
+    r47 :: bit
+    r48 :: bool
+    r49 :: bit
+    r50, r51, r52 :: tuple[object, object, object]
+    r53 :: object
+    r54 :: object[4]
+    r55 :: object_ptr
+    r56 :: object
+    r57 :: bit
+    r58 :: dict
+    r59 :: bool
+    r60 :: tuple[int, int]
+    r61 :: object
+    r62 :: i32
+    r63 :: bit
+    r64 :: object
+    r65 :: bool
+    r66 :: tuple[object, union[object, None]]
+    r67 :: tuple[object, object]
+L0:
+    r0 = faster_eth_abi.utils.numeric._unsigned_fixed_bounds_cache :: static
+    if is_error(r0) goto L1 else goto L3
+L1:
+    r1 = raise NameError('value for final name "_unsigned_fixed_bounds_cache" was not set')
+    if not r1 goto L53 (error at compute_unsigned_fixed_bounds:56) else goto L2 :: bool
+L2:
+    unreachable
+L3:
+    inc_ref num_bits :: int
+    inc_ref frac_places :: int
+    r2 = (num_bits, frac_places)
+    r3 = box(tuple[int, int], r2)
+    r4 = CPyDict_GetWithNone(r0, r3)
+    dec_ref r3
+    if is_error(r4) goto L53 (error at compute_unsigned_fixed_bounds:56) else goto L4
+L4:
+    upper = r4
+    r5 = load_address _Py_NoneStruct
+    r6 = upper == r5
+    if r6 goto L5 else goto L49 :: bool
+L5:
+    r7 = compute_unsigned_integer_bounds(num_bits)
+    if is_error(r7) goto L54 (error at compute_unsigned_fixed_bounds:58) else goto L6
+L6:
+    r8 = r7[1]
+    dec_ref r7
+    r9 = faster_eth_abi.utils.numeric.abi_decimal_context :: static
+    if is_error(r9) goto L55 else goto L9
+L7:
+    r10 = raise NameError('value for final name "abi_decimal_context" was not set')
+    if not r10 goto L53 (error at compute_unsigned_fixed_bounds:60) else goto L8 :: bool
+L8:
+    unreachable
+L9:
+    r11 = decimal :: module
+    r12 = 'localcontext'
+    r13 = CPyObject_GetAttr(r11, r12)
+    if is_error(r13) goto L56 (error at compute_unsigned_fixed_bounds:60) else goto L10
+L10:
+    r14 = [r9]
+    r15 = load_address r14
+    r16 = PyObject_Vectorcall(r13, r15, 1, 0)
+    dec_ref r13
+    if is_error(r16) goto L56 (error at compute_unsigned_fixed_bounds:60) else goto L11
+L11:
+    r17 = CPy_TYPE(r16)
+    r18 = '__exit__'
+    r19 = CPyObject_GetAttr(r17, r18)
+    if is_error(r19) goto L57 (error at compute_unsigned_fixed_bounds:60) else goto L12
+L12:
+    r20 = '__enter__'
+    r21 = CPyObject_GetAttr(r17, r20)
+    dec_ref r17
+    if is_error(r21) goto L58 (error at compute_unsigned_fixed_bounds:60) else goto L13
+L13:
+    r22 = [r16]
+    r23 = load_address r22
+    r24 = PyObject_Vectorcall(r21, r23, 1, 0)
+    dec_ref r21
+    if is_error(r24) goto L58 (error at compute_unsigned_fixed_bounds:60) else goto L59
+L14:
+    r25 = 1
+L15:
+    r26 = faster_eth_abi.utils.numeric.Decimal :: static
+    if is_error(r26) goto L60 else goto L18
+L16:
+    r27 = raise NameError('value for final name "Decimal" was not set')
+    if not r27 goto L25 (error at compute_unsigned_fixed_bounds:61) else goto L61 :: bool
+L17:
+    unreachable
+L18:
+    r28 = box(int, r8)
+    r29 = [r28]
+    r30 = load_address r29
+    r31 = PyObject_Vectorcall(r26, r30, 1, 0)
+    if is_error(r31) goto L62 (error at compute_unsigned_fixed_bounds:61) else goto L19
+L19:
+    dec_ref r28
+    r32 = faster_eth_abi.utils.numeric.TEN :: static
+    if is_error(r32) goto L63 else goto L22
+L20:
+    r33 = raise NameError('value for final name "TEN" was not set')
+    if not r33 goto L25 (error at compute_unsigned_fixed_bounds:61) else goto L64 :: bool
+L21:
+    unreachable
+L22:
+    r34 = CPyTagged_Negate(frac_places)
+    r35 = box(int, r34)
+    r36 = CPyNumber_Power(r32, r35)
+    dec_ref r35
+    if is_error(r36) goto L65 (error at compute_unsigned_fixed_bounds:61) else goto L23
+L23:
+    r37 = PyNumber_Multiply(r31, r36)
+    dec_ref r31
+    dec_ref r36
+    if is_error(r37) goto L25 (error at compute_unsigned_fixed_bounds:61) else goto L66
+L24:
+    upper = r37
+    goto L33
+L25:
+    r38 = CPy_CatchError()
+    r25 = 0
+    r39 = CPy_GetExcInfo()
+    r40 = r39[0]
+    r41 = r39[1]
+    r42 = r39[2]
+    dec_ref r39
+    r43 = [r16, r40, r41, r42]
+    r44 = load_address r43
+    r45 = PyObject_Vectorcall(r19, r44, 4, 0)
+    if is_error(r45) goto L67 (error at compute_unsigned_fixed_bounds:60) else goto L26
+L26:
+    dec_ref r40
+    dec_ref r41
+    dec_ref r42
+    r46 = PyObject_IsTrue(r45)
+    dec_ref r45
+    r47 = r46 >= 0 :: signed
+    if not r47 goto L31 (error at compute_unsigned_fixed_bounds:60) else goto L27 :: bool
+L27:
+    r48 = truncate r46: i32 to builtins.bool
+    if r48 goto L30 else goto L28 :: bool
+L28:
+    CPy_Reraise()
+    if not 0 goto L31 else goto L68 :: bool
+L29:
+    unreachable
+L30:
+    CPy_RestoreExcInfo(r38)
+    dec_ref r38
+    goto L33
+L31:
+    CPy_RestoreExcInfo(r38)
+    dec_ref r38
+    r49 = CPy_KeepPropagating()
+    if not r49 goto L34 else goto L69 :: bool
+L32:
+    unreachable
+L33:
+    r50 = <error> :: tuple[object, object, object]
+    r51 = r50
+    goto L35
+L34:
+    r52 = CPy_CatchError()
+    r51 = r52
+L35:
+    if r25 goto L36 else goto L70 :: bool
+L36:
+    r53 = load_address _Py_NoneStruct
+    r54 = [r16, r53, r53, r53]
+    r55 = load_address r54
+    r56 = PyObject_Vectorcall(r19, r55, 4, 0)
+    dec_ref r19
+    if is_error(r56) goto L71 (error at compute_unsigned_fixed_bounds:60) else goto L72
+L37:
+    dec_ref r16
+L38:
+    if is_error(r51) goto L45 else goto L73
+L39:
+    CPy_Reraise()
+    if not 0 goto L41 else goto L74 :: bool
+L40:
+    unreachable
+L41:
+    if is_error(r51) goto L43 else goto L42
+L42:
+    CPy_RestoreExcInfo(r51)
+    xdec_ref r51
+L43:
+    r57 = CPy_KeepPropagating()
+    if not r57 goto L53 else goto L44 :: bool
+L44:
+    unreachable
+L45:
+    r58 = faster_eth_abi.utils.numeric._unsigned_fixed_bounds_cache :: static
+    if is_error(r58) goto L75 else goto L48
+L46:
+    r59 = raise NameError('value for final name "_unsigned_fixed_bounds_cache" was not set')
+    if not r59 goto L53 (error at compute_unsigned_fixed_bounds:63) else goto L47 :: bool
+L47:
+    unreachable
+L48:
+    inc_ref num_bits :: int
+    inc_ref frac_places :: int
+    r60 = (num_bits, frac_places)
+    r61 = box(tuple[int, int], r60)
+    r62 = CPyDict_SetItem(r58, r61, upper)
+    dec_ref r61
+    r63 = r62 >= 0 :: signed
+    if not r63 goto L54 (error at compute_unsigned_fixed_bounds:63) else goto L49 :: bool
+L49:
+    r64 = faster_eth_abi.utils.numeric.ZERO :: static
+    if is_error(r64) goto L76 else goto L52
+L50:
+    r65 = raise NameError('value for final name "ZERO" was not set')
+    if not r65 goto L53 (error at compute_unsigned_fixed_bounds:65) else goto L51 :: bool
+L51:
+    unreachable
+L52:
+    inc_ref r64
+    r66 = (r64, upper)
+    return r66
+L53:
+    r67 = <error> :: tuple[object, object]
+    return r67
+L54:
+    dec_ref upper
+    goto L53
+L55:
+    dec_ref upper
+    dec_ref r8 :: int
+    goto L7
+L56:
+    dec_ref upper
+    dec_ref r8 :: int
+    goto L53
+L57:
+    dec_ref upper
+    dec_ref r8 :: int
+    dec_ref r16
+    dec_ref r17
+    goto L53
+L58:
+    dec_ref upper
+    dec_ref r8 :: int
+    dec_ref r16
+    dec_ref r19
+    goto L53
+L59:
+    dec_ref r24
+    goto L14
+L60:
+    dec_ref r8 :: int
+    goto L16
+L61:
+    dec_ref upper
+    dec_ref r16
+    dec_ref r19
+    goto L17
+L62:
+    dec_ref r28
+    goto L25
+L63:
+    dec_ref r31
+    goto L20
+L64:
+    dec_ref upper
+    dec_ref r16
+    dec_ref r19
+    goto L21
+L65:
+    dec_ref r31
+    goto L25
+L66:
+    dec_ref upper
+    goto L24
+L67:
+    dec_ref r40
+    dec_ref r41
+    dec_ref r42
+    goto L31
+L68:
+    dec_ref upper
+    dec_ref r16
+    dec_ref r19
+    dec_ref r38
+    goto L29
+L69:
+    dec_ref upper
+    dec_ref r16
+    dec_ref r19
+    goto L32
+L70:
+    dec_ref r16
+    dec_ref r19
+    goto L38
+L71:
+    dec_ref upper
+    dec_ref r16
+    goto L41
+L72:
+    dec_ref r56
+    goto L37
+L73:
+    dec_ref upper
+    goto L39
+L74:
+    xdec_ref r51
+    goto L40
+L75:
+    dec_ref upper
+    goto L46
+L76:
+    dec_ref upper
+    goto L50
+
+def compute_signed_fixed_bounds(num_bits, frac_places):
+    num_bits, frac_places :: int
+    r0, lower, r1, upper :: object
+    r2 :: dict
+    r3 :: bool
+    r4 :: tuple[int, int]
+    r5, r6 :: object
+    r7, bounds :: union[tuple[object, object], None]
+    r8 :: object
+    r9 :: bit
+    r10 :: tuple[int, int]
+    r11, r12, r13, r14 :: int
+    r15 :: object
+    r16 :: bool
+    r17 :: object
+    r18 :: str
+    r19 :: object
+    r20 :: object[1]
+    r21 :: object_ptr
+    r22, r23 :: object
+    r24 :: str
+    r25 :: object
+    r26 :: str
+    r27 :: object
+    r28 :: object[1]
+    r29 :: object_ptr
+    r30 :: object
+    r31 :: bool
+    r32 :: object
+    r33 :: bool
+    r34 :: int
+    r35, r36, r37 :: object
+    r38 :: bool
+    r39 :: object
+    r40 :: object[1]
+    r41 :: object_ptr
+    r42, r43, r44 :: object
+    r45 :: bool
+    r46 :: object
+    r47 :: object[1]
+    r48 :: object_ptr
+    r49, r50 :: object
+    r51, r52 :: tuple[object, object, object]
+    r53, r54, r55 :: object
+    r56 :: object[4]
+    r57 :: object_ptr
+    r58 :: object
+    r59 :: i32
+    r60 :: bit
+    r61 :: bool
+    r62 :: bit
+    r63, r64, r65 :: tuple[object, object, object]
+    r66 :: object
+    r67 :: object[4]
+    r68 :: object_ptr
+    r69 :: object
+    r70 :: bit
+    r71, r72 :: bool
+    r73 :: tuple[object, object]
+    r74 :: object
+    r75 :: tuple[object, object]
+    r76 :: dict
+    r77 :: bool
+    r78 :: tuple[int, int]
+    r79, r80 :: object
+    r81 :: i32
+    r82 :: bit
+    r83, r84 :: tuple[object, object]
+L0:
+    r0 = <error> :: object
+    lower = r0
+    r1 = <error> :: object
+    upper = r1
+    r2 = faster_eth_abi.utils.numeric._signed_fixed_bounds_cache :: static
+    if is_error(r2) goto L65 else goto L3
+L1:
+    r3 = raise NameError('value for final name "_signed_fixed_bounds_cache" was not set')
+    if not r3 goto L64 (error at compute_signed_fixed_bounds:77) else goto L2 :: bool
+L2:
+    unreachable
+L3:
+    inc_ref num_bits :: int
+    inc_ref frac_places :: int
+    r4 = (num_bits, frac_places)
+    r5 = box(tuple[int, int], r4)
+    r6 = CPyDict_GetWithNone(r2, r5)
+    dec_ref r5
+    if is_error(r6) goto L66 (error at compute_signed_fixed_bounds:77) else goto L4
+L4:
+    r7 = cast(union[tuple[object, object], None], r6)
+    if is_error(r7) goto L66 (error at compute_signed_fixed_bounds:77) else goto L5
+L5:
+    bounds = r7
+    r8 = load_address _Py_NoneStruct
+    r9 = bounds == r8
+    if r9 goto L67 else goto L68 :: bool
+L6:
+    r10 = compute_signed_integer_bounds(num_bits)
+    if is_error(r10) goto L66 (error at compute_signed_fixed_bounds:79) else goto L7
+L7:
+    r11 = borrow r10[0]
+    r12 = borrow r10[1]
+    r13 = unborrow r11
+    r14 = unborrow r12
+    r15 = faster_eth_abi.utils.numeric.abi_decimal_context :: static
+    if is_error(r15) goto L69 else goto L10
+L8:
+    r16 = raise NameError('value for final name "abi_decimal_context" was not set')
+    if not r16 goto L64 (error at compute_signed_fixed_bounds:81) else goto L9 :: bool
+L9:
+    unreachable
+L10:
+    r17 = decimal :: module
+    r18 = 'localcontext'
+    r19 = CPyObject_GetAttr(r17, r18)
+    if is_error(r19) goto L70 (error at compute_signed_fixed_bounds:81) else goto L11
+L11:
+    r20 = [r15]
+    r21 = load_address r20
+    r22 = PyObject_Vectorcall(r19, r21, 1, 0)
+    dec_ref r19
+    if is_error(r22) goto L70 (error at compute_signed_fixed_bounds:81) else goto L12
+L12:
+    r23 = CPy_TYPE(r22)
+    r24 = '__exit__'
+    r25 = CPyObject_GetAttr(r23, r24)
+    if is_error(r25) goto L71 (error at compute_signed_fixed_bounds:81) else goto L13
+L13:
+    r26 = '__enter__'
+    r27 = CPyObject_GetAttr(r23, r26)
+    dec_ref r23
+    if is_error(r27) goto L72 (error at compute_signed_fixed_bounds:81) else goto L14
+L14:
+    r28 = [r22]
+    r29 = load_address r28
+    r30 = PyObject_Vectorcall(r27, r29, 1, 0)
+    dec_ref r27
+    if is_error(r30) goto L72 (error at compute_signed_fixed_bounds:81) else goto L73
+L15:
+    r31 = 1
+L16:
+    r32 = faster_eth_abi.utils.numeric.TEN :: static
+    if is_error(r32) goto L74 else goto L19
+L17:
+    r33 = raise NameError('value for final name "TEN" was not set')
+    if not r33 goto L31 (error at compute_signed_fixed_bounds:82) else goto L75 :: bool
+L18:
+    unreachable
+L19:
+    r34 = CPyTagged_Negate(frac_places)
+    r35 = box(int, r34)
+    r36 = CPyNumber_Power(r32, r35)
+    dec_ref r35
+    if is_error(r36) goto L76 (error at compute_signed_fixed_bounds:82) else goto L20
+L20:
+    r37 = faster_eth_abi.utils.numeric.Decimal :: static
+    if is_error(r37) goto L77 else goto L23
+L21:
+    r38 = raise NameError('value for final name "Decimal" was not set')
+    if not r38 goto L31 (error at compute_signed_fixed_bounds:83) else goto L78 :: bool
+L22:
+    unreachable
+L23:
+    r39 = box(int, r13)
+    r40 = [r39]
+    r41 = load_address r40
+    r42 = PyObject_Vectorcall(r37, r41, 1, 0)
+    if is_error(r42) goto L79 (error at compute_signed_fixed_bounds:83) else goto L24
+L24:
+    dec_ref r39
+    r43 = PyNumber_Multiply(r42, r36)
+    dec_ref r42
+    if is_error(r43) goto L80 (error at compute_signed_fixed_bounds:83) else goto L81
+L25:
+    lower = r43
+    r44 = faster_eth_abi.utils.numeric.Decimal :: static
+    if is_error(r44) goto L82 else goto L28
+L26:
+    r45 = raise NameError('value for final name "Decimal" was not set')
+    if not r45 goto L31 (error at compute_signed_fixed_bounds:84) else goto L83 :: bool
+L27:
+    unreachable
+L28:
+    r46 = box(int, r14)
+    r47 = [r46]
+    r48 = load_address r47
+    r49 = PyObject_Vectorcall(r44, r48, 1, 0)
+    if is_error(r49) goto L84 (error at compute_signed_fixed_bounds:84) else goto L29
+L29:
+    dec_ref r46
+    r50 = PyNumber_Multiply(r49, r36)
+    dec_ref r49
+    dec_ref r36
+    if is_error(r50) goto L31 (error at compute_signed_fixed_bounds:84) else goto L85
+L30:
+    upper = r50
+    goto L39
+L31:
+    r51 = CPy_CatchError()
+    r31 = 0
+    r52 = CPy_GetExcInfo()
+    r53 = r52[0]
+    r54 = r52[1]
+    r55 = r52[2]
+    dec_ref r52
+    r56 = [r22, r53, r54, r55]
+    r57 = load_address r56
+    r58 = PyObject_Vectorcall(r25, r57, 4, 0)
+    if is_error(r58) goto L86 (error at compute_signed_fixed_bounds:81) else goto L32
+L32:
+    dec_ref r53
+    dec_ref r54
+    dec_ref r55
+    r59 = PyObject_IsTrue(r58)
+    dec_ref r58
+    r60 = r59 >= 0 :: signed
+    if not r60 goto L37 (error at compute_signed_fixed_bounds:81) else goto L33 :: bool
+L33:
+    r61 = truncate r59: i32 to builtins.bool
+    if r61 goto L36 else goto L34 :: bool
+L34:
+    CPy_Reraise()
+    if not 0 goto L37 else goto L87 :: bool
+L35:
+    unreachable
+L36:
+    CPy_RestoreExcInfo(r51)
+    dec_ref r51
+    goto L39
+L37:
+    CPy_RestoreExcInfo(r51)
+    dec_ref r51
+    r62 = CPy_KeepPropagating()
+    if not r62 goto L40 else goto L88 :: bool
+L38:
+    unreachable
+L39:
+    r63 = <error> :: tuple[object, object, object]
+    r64 = r63
+    goto L41
+L40:
+    r65 = CPy_CatchError()
+    r64 = r65
+L41:
+    if r31 goto L42 else goto L89 :: bool
+L42:
+    r66 = load_address _Py_NoneStruct
+    r67 = [r22, r66, r66, r66]
+    r68 = load_address r67
+    r69 = PyObject_Vectorcall(r25, r68, 4, 0)
+    dec_ref r25
+    if is_error(r69) goto L90 (error at compute_signed_fixed_bounds:81) else goto L91
+L43:
+    dec_ref r22
+L44:
+    if is_error(r64) goto L51 else goto L92
+L45:
+    CPy_Reraise()
+    if not 0 goto L47 else goto L93 :: bool
+L46:
+    unreachable
+L47:
+    if is_error(r64) goto L49 else goto L48
+L48:
+    CPy_RestoreExcInfo(r64)
+    xdec_ref r64
+L49:
+    r70 = CPy_KeepPropagating()
+    if not r70 goto L64 else goto L50 :: bool
+L50:
+    unreachable
+L51:
+    if is_error(lower) goto L94 else goto L54
+L52:
+    r71 = raise UnboundLocalError('local variable "lower" referenced before assignment')
+    if not r71 goto L64 (error at compute_signed_fixed_bounds:86) else goto L53 :: bool
+L53:
+    unreachable
+L54:
+    if is_error(upper) goto L95 else goto L57
+L55:
+    r72 = raise UnboundLocalError('local variable "upper" referenced before assignment')
+    if not r72 goto L64 (error at compute_signed_fixed_bounds:86) else goto L56 :: bool
+L56:
+    unreachable
+L57:
+    r73 = (lower, upper)
+    r74 = box(tuple[object, object], r73)
+    bounds = r74
+    r75 = unbox(tuple[object, object], bounds)
+    if is_error(r75) goto L96 (error at compute_signed_fixed_bounds:87) else goto L58
+L58:
+    r76 = faster_eth_abi.utils.numeric._signed_fixed_bounds_cache :: static
+    if is_error(r76) goto L97 else goto L61
+L59:
+    r77 = raise NameError('value for final name "_signed_fixed_bounds_cache" was not set')
+    if not r77 goto L64 (error at compute_signed_fixed_bounds:87) else goto L60 :: bool
+L60:
+    unreachable
+L61:
+    inc_ref num_bits :: int
+    inc_ref frac_places :: int
+    r78 = (num_bits, frac_places)
+    r79 = box(tuple[int, int], r78)
+    r80 = box(tuple[object, object], r75)
+    r81 = CPyDict_SetItem(r76, r79, r80)
+    dec_ref r79
+    dec_ref r80
+    r82 = r81 >= 0 :: signed
+    if not r82 goto L96 (error at compute_signed_fixed_bounds:87) else goto L62 :: bool
+L62:
+    r83 = unbox(tuple[object, object], bounds)
+    dec_ref bounds
+    if is_error(r83) goto L64 (error at compute_signed_fixed_bounds:89) else goto L63
+L63:
+    return r83
+L64:
+    r84 = <error> :: tuple[object, object]
+    return r84
+L65:
+    xdec_ref lower
+    xdec_ref upper
+    goto L1
+L66:
+    xdec_ref lower
+    xdec_ref upper
+    goto L64
+L67:
+    dec_ref bounds
+    goto L6
+L68:
+    xdec_ref lower
+    xdec_ref upper
+    goto L62
+L69:
+    xdec_ref lower
+    xdec_ref upper
+    dec_ref r13 :: int
+    dec_ref r14 :: int
+    goto L8
+L70:
+    xdec_ref lower
+    xdec_ref upper
+    dec_ref r13 :: int
+    dec_ref r14 :: int
+    goto L64
+L71:
+    xdec_ref lower
+    xdec_ref upper
+    dec_ref r13 :: int
+    dec_ref r14 :: int
+    dec_ref r22
+    dec_ref r23
+    goto L64
+L72:
+    xdec_ref lower
+    xdec_ref upper
+    dec_ref r13 :: int
+    dec_ref r14 :: int
+    dec_ref r22
+    dec_ref r25
+    goto L64
+L73:
+    dec_ref r30
+    goto L15
+L74:
+    dec_ref r13 :: int
+    dec_ref r14 :: int
+    goto L17
+L75:
+    xdec_ref lower
+    xdec_ref upper
+    dec_ref r22
+    dec_ref r25
+    goto L18
+L76:
+    dec_ref r13 :: int
+    dec_ref r14 :: int
+    goto L31
+L77:
+    dec_ref r13 :: int
+    dec_ref r14 :: int
+    dec_ref r36
+    goto L21
+L78:
+    xdec_ref lower
+    xdec_ref upper
+    dec_ref r22
+    dec_ref r25
+    goto L22
+L79:
+    dec_ref r14 :: int
+    dec_ref r36
+    dec_ref r39
+    goto L31
+L80:
+    dec_ref r14 :: int
+    dec_ref r36
+    goto L31
+L81:
+    xdec_ref lower
+    goto L25
+L82:
+    dec_ref r14 :: int
+    dec_ref r36
+    goto L26
+L83:
+    dec_ref lower
+    xdec_ref upper
+    dec_ref r22
+    dec_ref r25
+    goto L27
+L84:
+    dec_ref r36
+    dec_ref r46
+    goto L31
+L85:
+    xdec_ref upper
+    goto L30
+L86:
+    dec_ref r53
+    dec_ref r54
+    dec_ref r55
+    goto L37
+L87:
+    xdec_ref lower
+    xdec_ref upper
+    dec_ref r22
+    dec_ref r25
+    dec_ref r51
+    goto L35
+L88:
+    xdec_ref lower
+    xdec_ref upper
+    dec_ref r22
+    dec_ref r25
+    goto L38
+L89:
+    dec_ref r22
+    dec_ref r25
+    goto L44
+L90:
+    xdec_ref lower
+    xdec_ref upper
+    dec_ref r22
+    goto L47
+L91:
+    dec_ref r69
+    goto L43
+L92:
+    xdec_ref lower
+    xdec_ref upper
+    goto L45
+L93:
+    xdec_ref r64
+    goto L46
+L94:
+    xdec_ref upper
+    goto L52
+L95:
+    xdec_ref lower
+    goto L55
+L96:
+    dec_ref bounds
+    goto L64
+L97:
+    dec_ref bounds
+    dec_ref r75
+    goto L59
+
+def f_scale_places_obj.__get__(__mypyc_self__, instance, owner):
+    __mypyc_self__, instance, owner, r0 :: object
+    r1 :: bit
+    r2, r3 :: object
+L0:
+    r0 = load_address _Py_NoneStruct
+    r1 = instance == r0
+    if r1 goto L1 else goto L2 :: bool
+L1:
+    inc_ref __mypyc_self__
+    return __mypyc_self__
+L2:
+    r2 = PyMethod_New(__mypyc_self__, instance)
+    if is_error(r2) goto L4 else goto L3
+L3:
+    return r2
+L4:
+    r3 = <error> :: object
+    return r3
+
+def f_scale_places_obj.__call__(__mypyc_self__, x):
+    __mypyc_self__ :: faster_eth_abi.utils.numeric.f_scale_places_obj
+    x :: object
+    r0 :: faster_eth_abi.utils.numeric.scale_places_env
+    r1 :: object
+    r2 :: bool
+    r3 :: object
+    r4 :: str
+    r5 :: object
+    r6 :: object[1]
+    r7 :: object_ptr
+    r8, r9 :: object
+    r10 :: str
+    r11 :: object
+    r12 :: str
+    r13 :: object
+    r14 :: object[1]
+    r15 :: object_ptr
+    r16 :: object
+    r17 :: bool
+    r18, r19, r20 :: object
+    r21, r22 :: tuple[object, object, object]
+    r23, r24, r25 :: object
+    r26 :: object[4]
+    r27 :: object_ptr
+    r28 :: object
+    r29 :: i32
+    r30 :: bit
+    r31 :: bool
+    r32 :: bit
+    r33 :: object
+    r34, r35 :: tuple[object, object, object]
+    r36 :: object
+    r37 :: tuple[object, object, object]
+    r38 :: object
+    r39 :: object[4]
+    r40 :: object_ptr
+    r41 :: object
+    r42 :: bit
+    r43, r44 :: object
+L0:
+    r0 = __mypyc_self__.__mypyc_env__
+    if is_error(r0) goto L37 (error at f:106) else goto L1
+L1:
+    r1 = faster_eth_abi.utils.numeric.abi_decimal_context :: static
+    if is_error(r1) goto L38 else goto L4
+L2:
+    r2 = raise NameError('value for final name "abi_decimal_context" was not set')
+    if not r2 goto L37 (error at f:107) else goto L3 :: bool
+L3:
+    unreachable
+L4:
+    r3 = decimal :: module
+    r4 = 'localcontext'
+    r5 = CPyObject_GetAttr(r3, r4)
+    if is_error(r5) goto L39 (error at f:107) else goto L5
+L5:
+    r6 = [r1]
+    r7 = load_address r6
+    r8 = PyObject_Vectorcall(r5, r7, 1, 0)
+    dec_ref r5
+    if is_error(r8) goto L39 (error at f:107) else goto L6
+L6:
+    r9 = CPy_TYPE(r8)
+    r10 = '__exit__'
+    r11 = CPyObject_GetAttr(r9, r10)
+    if is_error(r11) goto L40 (error at f:107) else goto L7
+L7:
+    r12 = '__enter__'
+    r13 = CPyObject_GetAttr(r9, r12)
+    dec_ref r9
+    if is_error(r13) goto L41 (error at f:107) else goto L8
+L8:
+    r14 = [r8]
+    r15 = load_address r14
+    r16 = PyObject_Vectorcall(r13, r15, 1, 0)
+    dec_ref r13
+    if is_error(r16) goto L41 (error at f:107) else goto L42
+L9:
+    r17 = 1
+L10:
+    r18 = r0.scaling_factor
+    dec_ref r0
+    if is_error(r18) goto L13 (error at f:108) else goto L11
+L11:
+    r19 = PyNumber_Multiply(x, r18)
+    dec_ref r18
+    if is_error(r19) goto L13 (error at f:108) else goto L12
+L12:
+    r20 = r19
+    goto L22
+L13:
+    r21 = CPy_CatchError()
+    r17 = 0
+    r22 = CPy_GetExcInfo()
+    r23 = r22[0]
+    r24 = r22[1]
+    r25 = r22[2]
+    dec_ref r22
+    r26 = [r8, r23, r24, r25]
+    r27 = load_address r26
+    r28 = PyObject_Vectorcall(r11, r27, 4, 0)
+    if is_error(r28) goto L43 (error at f:107) else goto L14
+L14:
+    dec_ref r23
+    dec_ref r24
+    dec_ref r25
+    r29 = PyObject_IsTrue(r28)
+    dec_ref r28
+    r30 = r29 >= 0 :: signed
+    if not r30 goto L19 (error at f:107) else goto L15 :: bool
+L15:
+    r31 = truncate r29: i32 to builtins.bool
+    if r31 goto L18 else goto L16 :: bool
+L16:
+    CPy_Reraise()
+    if not 0 goto L19 else goto L44 :: bool
+L17:
+    unreachable
+L18:
+    CPy_RestoreExcInfo(r21)
+    dec_ref r21
+    goto L21
+L19:
+    CPy_RestoreExcInfo(r21)
+    dec_ref r21
+    r32 = CPy_KeepPropagating()
+    if not r32 goto L23 else goto L45 :: bool
+L20:
+    unreachable
+L21:
+    r33 = <error> :: object
+    r20 = r33
+L22:
+    r34 = <error> :: tuple[object, object, object]
+    r35 = r34
+    goto L24
+L23:
+    r36 = <error> :: object
+    r20 = r36
+    r37 = CPy_CatchError()
+    r35 = r37
+L24:
+    if r17 goto L25 else goto L46 :: bool
+L25:
+    r38 = load_address _Py_NoneStruct
+    r39 = [r8, r38, r38, r38]
+    r40 = load_address r39
+    r41 = PyObject_Vectorcall(r11, r40, 4, 0)
+    dec_ref r11
+    if is_error(r41) goto L47 (error at f:107) else goto L48
+L26:
+    dec_ref r8
+L27:
+    if is_error(r35) goto L30 else goto L49
+L28:
+    CPy_Reraise()
+    if not 0 goto L32 else goto L50 :: bool
+L29:
+    unreachable
+L30:
+    if is_error(r20) goto L36 else goto L31
+L31:
+    return r20
+L32:
+    if is_error(r35) goto L34 else goto L33
+L33:
+    CPy_RestoreExcInfo(r35)
+    xdec_ref r35
+L34:
+    r42 = CPy_KeepPropagating()
+    if not r42 goto L37 else goto L35 :: bool
+L35:
+    unreachable
+L36:
+    r43 = box(None, 1)
+    inc_ref r43
+    return r43
+L37:
+    r44 = <error> :: object
+    return r44
+L38:
+    dec_ref r0
+    goto L2
+L39:
+    dec_ref r0
+    goto L37
+L40:
+    dec_ref r0
+    dec_ref r8
+    dec_ref r9
+    goto L37
+L41:
+    dec_ref r0
+    dec_ref r8
+    dec_ref r11
+    goto L37
+L42:
+    dec_ref r16
+    goto L9
+L43:
+    dec_ref r23
+    dec_ref r24
+    dec_ref r25
+    goto L19
+L44:
+    dec_ref r8
+    dec_ref r11
+    dec_ref r21
+    goto L17
+L45:
+    dec_ref r8
+    dec_ref r11
+    goto L20
+L46:
+    dec_ref r8
+    dec_ref r11
+    goto L27
+L47:
+    dec_ref r8
+    xdec_ref r20
+    goto L32
+L48:
+    dec_ref r41
+    goto L26
+L49:
+    xdec_ref r20
+    goto L28
+L50:
+    xdec_ref r35
+    goto L29
+
+def scale_places(places):
+    places :: int
+    r0 :: faster_eth_abi.utils.numeric.scale_places_env
+    r1 :: object
+    r2 :: bit
+    r3, r4, r5 :: str
+    r6 :: object
+    r7, r8 :: str
+    r9 :: object[3]
+    r10 :: object_ptr
+    r11 :: object
+    r12, r13 :: str
+    r14, r15 :: object
+    r16, r17 :: str
+    r18 :: object[3]
+    r19 :: object_ptr
+    r20 :: object
+    r21 :: str
+    r22 :: list
+    r23, r24, r25, r26, r27, r28 :: ptr
+    r29 :: str
+    r30 :: object
+    r31 :: str
+    r32 :: object
+    r33 :: object[1]
+    r34 :: object_ptr
+    r35, r36 :: object
+    r37 :: bool
+    r38 :: object
+    r39 :: str
+    r40 :: object
+    r41 :: object[1]
+    r42 :: object_ptr
+    r43, r44 :: object
+    r45 :: str
+    r46 :: object
+    r47 :: str
+    r48 :: object
+    r49 :: object[1]
+    r50 :: object_ptr
+    r51 :: object
+    r52 :: bool
+    r53 :: object
+    r54 :: bool
+    r55 :: int
+    r56, r57 :: object
+    r58 :: bool
+    r59, r60 :: tuple[object, object, object]
+    r61, r62, r63 :: object
+    r64 :: object[4]
+    r65 :: object_ptr
+    r66 :: object
+    r67 :: i32
+    r68 :: bit
+    r69 :: bool
+    r70 :: bit
+    r71, r72, r73 :: tuple[object, object, object]
+    r74 :: object
+    r75 :: object[4]
+    r76 :: object_ptr
+    r77 :: object
+    r78 :: bit
+    r79 :: faster_eth_abi.utils.numeric.f_scale_places_obj
+    r80 :: bool
+    f :: object
+    r81 :: native_int
+    r82 :: bit
+    r83 :: native_int
+    r84, r85, r86 :: bit
+    r87, r88, r89, r90, r91 :: str
+    r92 :: int
+    r93, r94, places_repr, r95, r96, r97 :: str
+    r98 :: i32
+    r99 :: bit
+    r100 :: str
+    r101 :: i32
+    r102 :: bit
+    r103 :: object
+L0:
+    r0 = scale_places_env()
+    if is_error(r0) goto L60 (error at scale_places:92) else goto L1
+L1:
+    inc_ref places :: int
+    r1 = box(int, places)
+    r2 = PyLong_Check(r1)
+    dec_ref r1
+    if r2 goto L10 else goto L61 :: bool
+L2:
+    r3 = ''
+    r4 = 'Argument `places` must be int.  Got value '
+    r5 = '{:{}}'
+    inc_ref places :: int
+    r6 = box(int, places)
+    r7 = ''
+    r8 = 'format'
+    r9 = [r5, r6, r7]
+    r10 = load_address r9
+    r11 = PyObject_VectorcallMethod(r8, r10, 9223372036854775811, 0)
+    if is_error(r11) goto L62 (error at scale_places:99) else goto L3
+L3:
+    dec_ref r6
+    r12 = ' of type '
+    r13 = '{:{}}'
+    inc_ref places :: int
+    r14 = box(int, places)
+    r15 = CPy_TYPE(r14)
+    dec_ref r14
+    r16 = ''
+    r17 = 'format'
+    r18 = [r13, r15, r16]
+    r19 = load_address r18
+    r20 = PyObject_VectorcallMethod(r17, r19, 9223372036854775811, 0)
+    if is_error(r20) goto L63 (error at scale_places:100) else goto L4
+L4:
+    dec_ref r15
+    r21 = '.'
+    r22 = PyList_New(5)
+    if is_error(r22) goto L64 (error at scale_places:99) else goto L5
+L5:
+    r23 = get_element_ptr r22 ob_item :: PyListObject
+    r24 = load_mem r23 :: ptr*
+    inc_ref r4
+    set_mem r24, r4 :: builtins.object*
+    r25 = r24 + 8
+    set_mem r25, r11 :: builtins.object*
+    inc_ref r12
+    r26 = r24 + 16
+    set_mem r26, r12 :: builtins.object*
+    r27 = r24 + 24
+    set_mem r27, r20 :: builtins.object*
+    inc_ref r21
+    r28 = r24 + 32
+    set_mem r28, r21 :: builtins.object*
+    r29 = PyUnicode_Join(r3, r22)
+    dec_ref r22
+    if is_error(r29) goto L60 (error at scale_places:99) else goto L6
+L6:
+    r30 = builtins :: module
+    r31 = 'ValueError'
+    r32 = CPyObject_GetAttr(r30, r31)
+    if is_error(r32) goto L65 (error at scale_places:98) else goto L7
+L7:
+    r33 = [r29]
+    r34 = load_address r33
+    r35 = PyObject_Vectorcall(r32, r34, 1, 0)
+    dec_ref r32
+    if is_error(r35) goto L65 (error at scale_places:98) else goto L8
+L8:
+    dec_ref r29
+    CPy_Raise(r35)
+    dec_ref r35
+    if not 0 goto L60 (error at scale_places:98) else goto L9 :: bool
+L9:
+    unreachable
+L10:
+    r36 = faster_eth_abi.utils.numeric.abi_decimal_context :: static
+    if is_error(r36) goto L66 else goto L13
+L11:
+    r37 = raise NameError('value for final name "abi_decimal_context" was not set')
+    if not r37 goto L60 (error at scale_places:103) else goto L12 :: bool
+L12:
+    unreachable
+L13:
+    r38 = decimal :: module
+    r39 = 'localcontext'
+    r40 = CPyObject_GetAttr(r38, r39)
+    if is_error(r40) goto L67 (error at scale_places:103) else goto L14
+L14:
+    r41 = [r36]
+    r42 = load_address r41
+    r43 = PyObject_Vectorcall(r40, r42, 1, 0)
+    dec_ref r40
+    if is_error(r43) goto L67 (error at scale_places:103) else goto L15
+L15:
+    r44 = CPy_TYPE(r43)
+    r45 = '__exit__'
+    r46 = CPyObject_GetAttr(r44, r45)
+    if is_error(r46) goto L68 (error at scale_places:103) else goto L16
+L16:
+    r47 = '__enter__'
+    r48 = CPyObject_GetAttr(r44, r47)
+    dec_ref r44
+    if is_error(r48) goto L69 (error at scale_places:103) else goto L17
+L17:
+    r49 = [r43]
+    r50 = load_address r49
+    r51 = PyObject_Vectorcall(r48, r50, 1, 0)
+    dec_ref r48
+    if is_error(r51) goto L69 (error at scale_places:103) else goto L70
+L18:
+    r52 = 1
+L19:
+    r53 = faster_eth_abi.utils.numeric.TEN :: static
+    if is_error(r53) goto L20 else goto L22
+L20:
+    r54 = raise NameError('value for final name "TEN" was not set')
+    if not r54 goto L24 (error at scale_places:104) else goto L71 :: bool
+L21:
+    unreachable
+L22:
+    r55 = CPyTagged_Negate(places)
+    r56 = box(int, r55)
+    r57 = CPyNumber_Power(r53, r56)
+    dec_ref r56
+    if is_error(r57) goto L24 (error at scale_places:104) else goto L23
+L23:
+    r0.scaling_factor = r57; r58 = is_error
+    if not r58 goto L24 (error at scale_places:104) else goto L32 :: bool
+L24:
+    r59 = CPy_CatchError()
+    r52 = 0
+    r60 = CPy_GetExcInfo()
+    r61 = r60[0]
+    r62 = r60[1]
+    r63 = r60[2]
+    dec_ref r60
+    r64 = [r43, r61, r62, r63]
+    r65 = load_address r64
+    r66 = PyObject_Vectorcall(r46, r65, 4, 0)
+    if is_error(r66) goto L72 (error at scale_places:103) else goto L25
+L25:
+    dec_ref r61
+    dec_ref r62
+    dec_ref r63
+    r67 = PyObject_IsTrue(r66)
+    dec_ref r66
+    r68 = r67 >= 0 :: signed
+    if not r68 goto L30 (error at scale_places:103) else goto L26 :: bool
+L26:
+    r69 = truncate r67: i32 to builtins.bool
+    if r69 goto L29 else goto L27 :: bool
+L27:
+    CPy_Reraise()
+    if not 0 goto L30 else goto L73 :: bool
+L28:
+    unreachable
+L29:
+    CPy_RestoreExcInfo(r59)
+    dec_ref r59
+    goto L32
+L30:
+    CPy_RestoreExcInfo(r59)
+    dec_ref r59
+    r70 = CPy_KeepPropagating()
+    if not r70 goto L33 else goto L74 :: bool
+L31:
+    unreachable
+L32:
+    r71 = <error> :: tuple[object, object, object]
+    r72 = r71
+    goto L34
+L33:
+    r73 = CPy_CatchError()
+    r72 = r73
+L34:
+    if r52 goto L35 else goto L75 :: bool
+L35:
+    r74 = load_address _Py_NoneStruct
+    r75 = [r43, r74, r74, r74]
+    r76 = load_address r75
+    r77 = PyObject_Vectorcall(r46, r76, 4, 0)
+    dec_ref r46
+    if is_error(r77) goto L76 (error at scale_places:103) else goto L77
+L36:
+    dec_ref r43
+L37:
+    if is_error(r72) goto L44 else goto L78
+L38:
+    CPy_Reraise()
+    if not 0 goto L40 else goto L79 :: bool
+L39:
+    unreachable
+L40:
+    if is_error(r72) goto L42 else goto L41
+L41:
+    CPy_RestoreExcInfo(r72)
+    xdec_ref r72
+L42:
+    r78 = CPy_KeepPropagating()
+    if not r78 goto L60 else goto L43 :: bool
+L43:
+    unreachable
+L44:
+    r79 = f_scale_places_obj()
+    if is_error(r79) goto L67 (error at scale_places:106) else goto L45
+L45:
+    r79.__mypyc_env__ = r0; r80 = is_error
+    if not r80 goto L80 (error at scale_places:106) else goto L46 :: bool
+L46:
+    f = r79
+    r81 = places & 1
+    r82 = r81 != 0
+    if r82 goto L48 else goto L47 :: bool
+L47:
+    r83 = 0 & 1
+    r84 = r83 != 0
+    if r84 goto L48 else goto L49 :: bool
+L48:
+    r85 = CPyTagged_IsLt_(0, places)
+    if r85 goto L50 else goto L53 :: bool
+L49:
+    r86 = places > 0 :: signed
+    if r86 goto L50 else goto L53 :: bool
+L50:
+    r87 = 'Eneg'
+    r88 = CPyTagged_Str(places)
+    if is_error(r88) goto L81 (error at scale_places:110) else goto L51
+L51:
+    r89 = CPyStr_Build(2, r87, r88)
+    dec_ref r88
+    if is_error(r89) goto L81 (error at scale_places:110) else goto L52
+L52:
+    r90 = r89
+    goto L56
+L53:
+    r91 = 'Epos'
+    r92 = CPyTagged_Negate(places)
+    r93 = CPyTagged_Str(r92)
+    dec_ref r92 :: int
+    if is_error(r93) goto L81 (error at scale_places:110) else goto L54
+L54:
+    r94 = CPyStr_Build(2, r91, r93)
+    dec_ref r93
+    if is_error(r94) goto L81 (error at scale_places:110) else goto L55
+L55:
+    r90 = r94
+L56:
+    places_repr = r90
+    r95 = 'scale_by_'
+    r96 = CPyStr_Build(2, r95, places_repr)
+    dec_ref places_repr
+    if is_error(r96) goto L81 (error at scale_places:111) else goto L57
+L57:
+    r97 = '__name__'
+    r98 = PyObject_SetAttr(f, r97, r96)
+    r99 = r98 >= 0 :: signed
+    if not r99 goto L82 (error at scale_places:113) else goto L58 :: bool
+L58:
+    r100 = '__qualname__'
+    r101 = PyObject_SetAttr(f, r100, r96)
+    dec_ref r96
+    r102 = r101 >= 0 :: signed
+    if not r102 goto L81 (error at scale_places:114) else goto L59 :: bool
+L59:
+    return f
+L60:
+    r103 = <error> :: object
+    return r103
+L61:
+    dec_ref r0
+    goto L2
+L62:
+    dec_ref r6
+    goto L60
+L63:
+    dec_ref r11
+    dec_ref r15
+    goto L60
+L64:
+    dec_ref r11
+    dec_ref r20
+    goto L60
+L65:
+    dec_ref r29
+    goto L60
+L66:
+    dec_ref r0
+    goto L11
+L67:
+    dec_ref r0
+    goto L60
+L68:
+    dec_ref r0
+    dec_ref r43
+    dec_ref r44
+    goto L60
+L69:
+    dec_ref r0
+    dec_ref r43
+    dec_ref r46
+    goto L60
+L70:
+    dec_ref r51
+    goto L18
+L71:
+    dec_ref r0
+    dec_ref r43
+    dec_ref r46
+    goto L21
+L72:
+    dec_ref r61
+    dec_ref r62
+    dec_ref r63
+    goto L30
+L73:
+    dec_ref r0
+    dec_ref r43
+    dec_ref r46
+    dec_ref r59
+    goto L28
+L74:
+    dec_ref r0
+    dec_ref r43
+    dec_ref r46
+    goto L31
+L75:
+    dec_ref r43
+    dec_ref r46
+    goto L37
+L76:
+    dec_ref r0
+    dec_ref r43
+    goto L40
+L77:
+    dec_ref r77
+    goto L36
+L78:
+    dec_ref r0
+    goto L38
+L79:
+    xdec_ref r72
+    goto L39
+L80:
+    dec_ref r79
+    goto L60
+L81:
+    dec_ref f
+    goto L60
+L82:
+    dec_ref f
+    dec_ref r96
+    goto L60
+
+def __top_level__():
+    r0, r1 :: object
+    r2 :: bit
+    r3 :: str
+    r4 :: object
+    r5 :: object_ptr
+    r6 :: object_ptr[1]
+    r7 :: c_ptr
+    r8 :: native_int[1]
+    r9 :: c_ptr
+    r10 :: object
+    r11 :: dict
+    r12, r13 :: str
+    r14 :: bit
+    r15 :: object
+    r16 :: str
+    r17 :: dict
+    r18 :: object
+    r19 :: dict
+    r20 :: str
+    r21 :: object
+    r22 :: i32
+    r23 :: bit
+    r24 :: object
+    r25 :: str
+    r26, r27 :: object
+    r28 :: object[1]
+    r29 :: object_ptr
+    r30, r31 :: object
+    r32 :: dict
+    r33 :: str
+    r34 :: i32
+    r35 :: bit
+    r36 :: object
+    r37 :: str
+    r38, r39 :: object
+    r40 :: object[1]
+    r41 :: object_ptr
+    r42 :: object
+    r43 :: dict
+    r44 :: str
+    r45 :: i32
+    r46 :: bit
+    r47 :: object
+    r48 :: str
+    r49, r50 :: object
+    r51 :: object[1]
+    r52 :: object_ptr
+    r53 :: object
+    r54 :: dict
+    r55 :: str
+    r56 :: i32
+    r57 :: bit
+    r58 :: object
+    r59 :: str
+    r60 :: object
+    r61 :: dict
+    r62 :: str
+    r63 :: i32
+    r64 :: bit
+    r65, r66 :: dict
+    r67 :: str
+    r68 :: i32
+    r69 :: bit
+    r70, r71 :: dict
+    r72 :: str
+    r73 :: i32
+    r74 :: bit
+    r75, r76 :: dict
+    r77 :: str
+    r78 :: i32
+    r79 :: bit
+    r80, r81 :: dict
+    r82 :: str
+    r83 :: i32
+    r84 :: bit
+    r85 :: None
+L0:
+    r0 = builtins :: module
+    r1 = load_address _Py_NoneStruct
+    r2 = r0 != r1
+    if r2 goto L3 else goto L1 :: bool
+L1:
+    r3 = 'builtins'
+    r4 = PyImport_Import(r3)
+    if is_error(r4) goto L26 (error at <module>:-1) else goto L2
+L2:
+    builtins = r4 :: module
+    dec_ref r4
+L3:
+    r5 = load_address decimal :: module
+    r6 = [r5]
+    r7 = load_address r6
+    r8 = [1]
+    r9 = load_address r8
+    r10 = (('decimal', 'decimal', 'decimal'),)
+    r11 = faster_eth_abi.utils.numeric.globals :: static
+    r12 = 'faster_eth_abi/utils/numeric.py'
+    r13 = '<module>'
+    r14 = CPyImport_ImportMany(r10, r7, r11, r12, r13, r9)
+    if not r14 goto L26 else goto L4 :: bool
+L4:
+    r15 = ('Callable', 'Dict', 'Final', 'Tuple')
+    r16 = 'typing'
+    r17 = faster_eth_abi.utils.numeric.globals :: static
+    r18 = CPyImport_ImportFromMany(r16, r15, r15, r17)
+    if is_error(r18) goto L26 (error at <module>:2) else goto L5
+L5:
+    typing = r18 :: module
+    dec_ref r18
+    r19 = faster_eth_abi.utils.numeric.globals :: static
+    r20 = 'ABI_DECIMAL_PREC'
+    r21 = object 999
+    r22 = CPyDict_SetItem(r19, r20, r21)
+    r23 = r22 >= 0 :: signed
+    if not r23 goto L26 (error at <module>:9) else goto L6 :: bool
+L6:
+    r24 = decimal :: module
+    r25 = 'Context'
+    r26 = CPyObject_GetAttr(r24, r25)
+    if is_error(r26) goto L26 (error at <module>:11) else goto L7
+L7:
+    r27 = object 999
+    r28 = [r27]
+    r29 = load_address r28
+    r30 = ('prec',)
+    r31 = PyObject_Vectorcall(r26, r29, 0, r30)
+    dec_ref r26
+    if is_error(r31) goto L26 (error at <module>:11) else goto L8
+L8:
+    faster_eth_abi.utils.numeric.abi_decimal_context = r31 :: static
+    r32 = faster_eth_abi.utils.numeric.globals :: static
+    r33 = 'abi_decimal_context'
+    r34 = CPyDict_SetItem(r32, r33, r31)
+    dec_ref r31
+    r35 = r34 >= 0 :: signed
+    if not r35 goto L26 (error at <module>:11) else goto L9 :: bool
+L9:
+    r36 = decimal :: module
+    r37 = 'Decimal'
+    r38 = CPyObject_GetAttr(r36, r37)
+    if is_error(r38) goto L26 (error at <module>:13) else goto L10
+L10:
+    r39 = object 0
+    r40 = [r39]
+    r41 = load_address r40
+    r42 = PyObject_Vectorcall(r38, r41, 1, 0)
+    dec_ref r38
+    if is_error(r42) goto L26 (error at <module>:13) else goto L11
+L11:
+    faster_eth_abi.utils.numeric.ZERO = r42 :: static
+    r43 = faster_eth_abi.utils.numeric.globals :: static
+    r44 = 'ZERO'
+    r45 = CPyDict_SetItem(r43, r44, r42)
+    dec_ref r42
+    r46 = r45 >= 0 :: signed
+    if not r46 goto L26 (error at <module>:13) else goto L12 :: bool
+L12:
+    r47 = decimal :: module
+    r48 = 'Decimal'
+    r49 = CPyObject_GetAttr(r47, r48)
+    if is_error(r49) goto L26 (error at <module>:14) else goto L13
+L13:
+    r50 = object 10
+    r51 = [r50]
+    r52 = load_address r51
+    r53 = PyObject_Vectorcall(r49, r52, 1, 0)
+    dec_ref r49
+    if is_error(r53) goto L26 (error at <module>:14) else goto L14
+L14:
+    faster_eth_abi.utils.numeric.TEN = r53 :: static
+    r54 = faster_eth_abi.utils.numeric.globals :: static
+    r55 = 'TEN'
+    r56 = CPyDict_SetItem(r54, r55, r53)
+    dec_ref r53
+    r57 = r56 >= 0 :: signed
+    if not r57 goto L26 (error at <module>:14) else goto L15 :: bool
+L15:
+    r58 = decimal :: module
+    r59 = 'Decimal'
+    r60 = CPyObject_GetAttr(r58, r59)
+    if is_error(r60) goto L26 (error at <module>:16) else goto L16
+L16:
+    faster_eth_abi.utils.numeric.Decimal = r60 :: static
+    r61 = faster_eth_abi.utils.numeric.globals :: static
+    r62 = 'Decimal'
+    r63 = CPyDict_SetItem(r61, r62, r60)
+    dec_ref r60
+    r64 = r63 >= 0 :: signed
+    if not r64 goto L26 (error at <module>:16) else goto L17 :: bool
+L17:
+    r65 = PyDict_New()
+    if is_error(r65) goto L26 (error at <module>:24) else goto L18
+L18:
+    faster_eth_abi.utils.numeric._unsigned_integer_bounds_cache = r65 :: static
+    r66 = faster_eth_abi.utils.numeric.globals :: static
+    r67 = '_unsigned_integer_bounds_cache'
+    r68 = CPyDict_SetItem(r66, r67, r65)
+    dec_ref r65
+    r69 = r68 >= 0 :: signed
+    if not r69 goto L26 (error at <module>:24) else goto L19 :: bool
+L19:
+    r70 = PyDict_New()
+    if is_error(r70) goto L26 (error at <module>:35) else goto L20
+L20:
+    faster_eth_abi.utils.numeric._signed_integer_bounds_cache = r70 :: static
+    r71 = faster_eth_abi.utils.numeric.globals :: static
+    r72 = '_signed_integer_bounds_cache'
+    r73 = CPyDict_SetItem(r71, r72, r70)
+    dec_ref r70
+    r74 = r73 >= 0 :: signed
+    if not r74 goto L26 (error at <module>:35) else goto L21 :: bool
+L21:
+    r75 = PyDict_New()
+    if is_error(r75) goto L26 (error at <module>:49) else goto L22
+L22:
+    faster_eth_abi.utils.numeric._unsigned_fixed_bounds_cache = r75 :: static
+    r76 = faster_eth_abi.utils.numeric.globals :: static
+    r77 = '_unsigned_fixed_bounds_cache'
+    r78 = CPyDict_SetItem(r76, r77, r75)
+    dec_ref r75
+    r79 = r78 >= 0 :: signed
+    if not r79 goto L26 (error at <module>:49) else goto L23 :: bool
+L23:
+    r80 = PyDict_New()
+    if is_error(r80) goto L26 (error at <module>:70) else goto L24
+L24:
+    faster_eth_abi.utils.numeric._signed_fixed_bounds_cache = r80 :: static
+    r81 = faster_eth_abi.utils.numeric.globals :: static
+    r82 = '_signed_fixed_bounds_cache'
+    r83 = CPyDict_SetItem(r81, r82, r80)
+    dec_ref r80
+    r84 = r83 >= 0 :: signed
+    if not r84 goto L26 (error at <module>:70) else goto L25 :: bool
+L25:
+    return 1
+L26:
+    r85 = <error> :: None
+    return r85
+
+def encode_tuple(values, encoders):
+    values, encoders :: object
+    r0, r1 :: list
+    r2, r3, r4, r5 :: object
+    r6 :: str
+    r7, r8 :: object
+    r9 :: i32
+    r10 :: bit
+    r11 :: bool
+    r12 :: object
+    r13 :: i32
+    r14 :: bit
+    r15 :: object[1]
+    r16 :: object_ptr
+    r17 :: object
+    r18 :: bytes
+    r19 :: i32
+    r20 :: bit
+    r21 :: object[1]
+    r22 :: object_ptr
+    r23 :: object
+    r24 :: bytes
+    r25 :: i32
+    r26 :: bit
+    r27 :: bytes
+    r28 :: i32
+    r29, r30, r31 :: bit
+    r32 :: int
+    r33 :: native_int
+    r34 :: ptr
+    r35 :: native_int
+    r36 :: bit
+    r37, r38 :: ptr
+    r39 :: native_int
+    r40 :: ptr
+    r41 :: object
+    r42 :: union[bytes, None]
+    r43 :: object
+    r44 :: bit
+    r45 :: int
+    r46 :: bytes
+    r47 :: ptr
+    r48 :: native_int
+    r49 :: short_int
+    r50 :: int
+    r51 :: native_int
+    head_length :: int
+    r52 :: list
+    r53 :: object
+    r54, r55 :: ptr
+    total_offset :: int
+    r56 :: object
+    r57 :: list
+    r58 :: native_int
+    r59 :: ptr
+    r60 :: native_int
+    r61 :: bit
+    r62, r63 :: ptr
+    r64 :: native_int
+    r65 :: ptr
+    r66 :: object
+    r67 :: bytes
+    r68 :: ptr
+    r69 :: native_int
+    r70 :: short_int
+    r71 :: int
+    r72 :: object
+    r73 :: i32
+    r74 :: bit
+    r75 :: native_int
+    r76 :: list
+    r77, r78 :: native_int
+    r79 :: ptr
+    r80 :: native_int
+    r81 :: bit
+    r82 :: ptr
+    r83 :: native_int
+    r84 :: bit
+    r85, r86 :: ptr
+    r87 :: native_int
+    r88 :: ptr
+    r89 :: object
+    r90 :: union[bytes, None]
+    r91, r92 :: ptr
+    r93 :: native_int
+    r94 :: ptr
+    r95 :: object
+    r96 :: int
+    r97 :: object
+    r98 :: bit
+    r99 :: int
+    r100, r101, r102 :: bytes
+    r103 :: i32
+    r104 :: bit
+    r105, r106 :: native_int
+    r107 :: tuple
+    r108, r109, r110, r111, r112, r113 :: bytes
+L0:
+    r0 = PyList_New(0)
+    if is_error(r0) goto L54 (error at encode_tuple:24) else goto L1
+L1:
+    r1 = PyList_New(0)
+    if is_error(r1) goto L55 (error at encode_tuple:25) else goto L2
+L2:
+    r2 = PyObject_GetIter(values)
+    if is_error(r2) goto L56 (error at encode_tuple:26) else goto L3
+L3:
+    r3 = PyObject_GetIter(encoders)
+    if is_error(r3) goto L57 (error at encode_tuple:26) else goto L4
+L4:
+    r4 = PyIter_Next(r2)
+    if is_error(r4) goto L58 else goto L5
+L5:
+    r5 = PyIter_Next(r3)
+    if is_error(r5) goto L59 else goto L6
+L6:
+    r6 = 'is_dynamic'
+    r7 = box(bool, 0)
+    r8 = CPyObject_GetAttr3(r5, r6, r7)
+    if is_error(r8) goto L60 (error at encode_tuple:27) else goto L7
+L7:
+    r9 = PyObject_IsTrue(r8)
+    dec_ref r8
+    r10 = r9 >= 0 :: signed
+    if not r10 goto L60 (error at encode_tuple:27) else goto L8 :: bool
+L8:
+    r11 = truncate r9: i32 to builtins.bool
+    if r11 goto L9 else goto L13 :: bool
+L9:
+    r12 = box(None, 1)
+    r13 = PyList_Append(r0, r12)
+    r14 = r13 >= 0 :: signed
+    if not r14 goto L60 (error at encode_tuple:28) else goto L10 :: bool
+L10:
+    r15 = [r4]
+    r16 = load_address r15
+    r17 = PyObject_Vectorcall(r5, r16, 1, 0)
+    dec_ref r5
+    if is_error(r17) goto L61 (error at encode_tuple:29) else goto L11
+L11:
+    dec_ref r4
+    r18 = cast(bytes, r17)
+    if is_error(r18) goto L62 (error at encode_tuple:29) else goto L12
+L12:
+    r19 = PyList_Append(r1, r18)
+    dec_ref r18
+    r20 = r19 >= 0 :: signed
+    if not r20 goto L62 (error at encode_tuple:29) else goto L4 :: bool
+L13:
+    r21 = [r4]
+    r22 = load_address r21
+    r23 = PyObject_Vectorcall(r5, r22, 1, 0)
+    dec_ref r5
+    if is_error(r23) goto L61 (error at encode_tuple:31) else goto L14
+L14:
+    dec_ref r4
+    r24 = cast(bytes, r23)
+    if is_error(r24) goto L62 (error at encode_tuple:31) else goto L15
+L15:
+    r25 = PyList_Append(r0, r24)
+    dec_ref r24
+    r26 = r25 >= 0 :: signed
+    if not r26 goto L62 (error at encode_tuple:31) else goto L16 :: bool
+L16:
+    r27 = b''
+    r28 = PyList_Append(r1, r27)
+    r29 = r28 >= 0 :: signed
+    if not r29 goto L62 (error at encode_tuple:32) else goto L4 :: bool
+L17:
+    r30 = CPy_NoErrOccurred()
+    if not r30 goto L56 (error at encode_tuple:26) else goto L18 :: bool
+L18:
+    r31 = CPy_NoErrOccurred()
+    if not r31 goto L56 (error at encode_tuple:26) else goto L19 :: bool
+L19:
+    r32 = 0
+    r33 = 0
+L20:
+    r34 = get_element_ptr r0 ob_size :: PyVarObject
+    r35 = load_mem r34 :: native_int*
+    r36 = r33 < r35 :: signed
+    if r36 goto L21 else goto L28 :: bool
+L21:
+    r37 = get_element_ptr r0 ob_item :: PyListObject
+    r38 = load_mem r37 :: ptr*
+    r39 = r33 * 8
+    r40 = r38 + r39
+    r41 = load_mem r40 :: builtins.object*
+    r42 = cast(union[bytes, None], r41)
+    if is_error(r42) goto L63 (error at encode_tuple:34) else goto L22
+L22:
+    r43 = load_address _Py_NoneStruct
+    r44 = r42 == r43
+    if r44 goto L64 else goto L24 :: bool
+L23:
+    r45 = 64
+    goto L26
+L24:
+    r46 = cast(bytes, r42)
+    if is_error(r46) goto L63 (error at encode_tuple:34) else goto L25
+L25:
+    r47 = get_element_ptr r46 ob_size :: PyVarObject
+    r48 = load_mem r47 :: native_int*
+    dec_ref r46
+    r49 = r48 << 1
+    r45 = r49
+L26:
+    r50 = CPyTagged_Add(r32, r45)
+    dec_ref r32 :: int
+    dec_ref r45 :: int
+    r32 = r50
+L27:
+    r51 = r33 + 1
+    r33 = r51
+    goto L20
+L28:
+    head_length = r32
+    r52 = PyList_New(1)
+    if is_error(r52) goto L65 (error at encode_tuple:35) else goto L29
+L29:
+    r53 = object 0
+    r54 = get_element_ptr r52 ob_item :: PyListObject
+    r55 = load_mem r54 :: ptr*
+    inc_ref r53
+    set_mem r55, r53 :: builtins.object*
+    total_offset = 0
+    r56 = CPyList_GetSlice(r1, 0, -2)
+    if is_error(r56) goto L66 (error at encode_tuple:37) else goto L30
+L30:
+    r57 = cast(list, r56)
+    if is_error(r57) goto L66 (error at encode_tuple:37) else goto L31
+L31:
+    r58 = 0
+L32:
+    r59 = get_element_ptr r57 ob_size :: PyVarObject
+    r60 = load_mem r59 :: native_int*
+    r61 = r58 < r60 :: signed
+    if r61 goto L33 else goto L67 :: bool
+L33:
+    r62 = get_element_ptr r57 ob_item :: PyListObject
+    r63 = load_mem r62 :: ptr*
+    r64 = r58 * 8
+    r65 = r63 + r64
+    r66 = load_mem r65 :: builtins.object*
+    r67 = cast(bytes, r66)
+    if is_error(r67) goto L68 (error at encode_tuple:37) else goto L34
+L34:
+    r68 = get_element_ptr r67 ob_size :: PyVarObject
+    r69 = load_mem r68 :: native_int*
+    dec_ref r67
+    r70 = r69 << 1
+    r71 = CPyTagged_Add(total_offset, r70)
+    dec_ref total_offset :: int
+    total_offset = r71
+    inc_ref total_offset :: int
+    r72 = box(int, total_offset)
+    r73 = PyList_Append(r52, r72)
+    dec_ref r72
+    r74 = r73 >= 0 :: signed
+    if not r74 goto L68 (error at encode_tuple:39) else goto L35 :: bool
+L35:
+    r75 = r58 + 1
+    r58 = r75
+    goto L32
+L36:
+    r76 = PyList_New(0)
+    if is_error(r76) goto L69 (error at encode_tuple:41) else goto L37
+L37:
+    r77 = 0
+    r78 = 0
+L38:
+    r79 = get_element_ptr r0 ob_size :: PyVarObject
+    r80 = load_mem r79 :: native_int*
+    r81 = r77 < r80 :: signed
+    if r81 goto L39 else goto L70 :: bool
+L39:
+    r82 = get_element_ptr r52 ob_size :: PyVarObject
+    r83 = load_mem r82 :: native_int*
+    r84 = r78 < r83 :: signed
+    if r84 goto L40 else goto L70 :: bool
+L40:
+    r85 = get_element_ptr r0 ob_item :: PyListObject
+    r86 = load_mem r85 :: ptr*
+    r87 = r77 * 8
+    r88 = r86 + r87
+    r89 = load_mem r88 :: builtins.object*
+    r90 = cast(union[bytes, None], r89)
+    if is_error(r90) goto L71 (error at encode_tuple:41) else goto L41
+L41:
+    r91 = get_element_ptr r52 ob_item :: PyListObject
+    r92 = load_mem r91 :: ptr*
+    r93 = r78 * 8
+    r94 = r92 + r93
+    r95 = load_mem r94 :: builtins.object*
+    r96 = unbox(int, r95)
+    dec_ref r95
+    if is_error(r96) goto L72 (error at encode_tuple:41) else goto L42
+L42:
+    r97 = load_address _Py_NoneStruct
+    r98 = r90 == r97
+    if r98 goto L73 else goto L74 :: bool
+L43:
+    r99 = CPyTagged_Add(head_length, r96)
+    dec_ref r96 :: int
+    r100 = encode_uint_256(r99)
+    dec_ref r99 :: int
+    if is_error(r100) goto L71 (error at encode_tuple:42) else goto L44
+L44:
+    r101 = r100
+    goto L47
+L45:
+    r102 = cast(bytes, r90)
+    if is_error(r102) goto L71 (error at encode_tuple:42) else goto L46
+L46:
+    r101 = r102
+L47:
+    r103 = PyList_Append(r76, r101)
+    dec_ref r101
+    r104 = r103 >= 0 :: signed
+    if not r104 goto L71 (error at encode_tuple:41) else goto L48 :: bool
+L48:
+    r105 = r77 + 1
+    r77 = r105
+    r106 = r78 + 1
+    r78 = r106
+    goto L38
+L49:
+    r107 = PyList_AsTuple(r76)
+    dec_ref r76
+    if is_error(r107) goto L75 (error at encode_tuple:41) else goto L50
+L50:
+    r108 = b''
+    r109 = CPyBytes_Join(r108, r107)
+    dec_ref r107
+    if is_error(r109) goto L75 (error at encode_tuple:46) else goto L51
+L51:
+    r110 = b''
+    r111 = CPyBytes_Join(r110, r1)
+    dec_ref r1
+    if is_error(r111) goto L76 (error at encode_tuple:46) else goto L52
+L52:
+    r112 = CPyBytes_Concat(r109, r111)
+    dec_ref r111
+    if is_error(r112) goto L54 (error at encode_tuple:46) else goto L53
+L53:
+    return r112
+L54:
+    r113 = <error> :: bytes
+    return r113
+L55:
+    dec_ref r0
+    goto L54
+L56:
+    dec_ref r0
+    dec_ref r1
+    goto L54
+L57:
+    dec_ref r0
+    dec_ref r1
+    dec_ref r2
+    goto L54
+L58:
+    dec_ref r2
+    dec_ref r3
+    goto L17
+L59:
+    dec_ref r2
+    dec_ref r3
+    dec_ref r4
+    goto L17
+L60:
+    dec_ref r0
+    dec_ref r1
+    dec_ref r2
+    dec_ref r3
+    dec_ref r4
+    dec_ref r5
+    goto L54
+L61:
+    dec_ref r0
+    dec_ref r1
+    dec_ref r2
+    dec_ref r3
+    dec_ref r4
+    goto L54
+L62:
+    dec_ref r0
+    dec_ref r1
+    dec_ref r2
+    dec_ref r3
+    goto L54
+L63:
+    dec_ref r0
+    dec_ref r1
+    dec_ref r32 :: int
+    goto L54
+L64:
+    dec_ref r42
+    goto L23
+L65:
+    dec_ref r0
+    dec_ref r1
+    dec_ref head_length :: int
+    goto L54
+L66:
+    dec_ref r0
+    dec_ref r1
+    dec_ref head_length :: int
+    dec_ref r52
+    dec_ref total_offset :: int
+    goto L54
+L67:
+    dec_ref total_offset :: int
+    dec_ref r57
+    goto L36
+L68:
+    dec_ref r0
+    dec_ref r1
+    dec_ref head_length :: int
+    dec_ref r52
+    dec_ref total_offset :: int
+    dec_ref r57
+    goto L54
+L69:
+    dec_ref r0
+    dec_ref r1
+    dec_ref head_length :: int
+    dec_ref r52
+    goto L54
+L70:
+    dec_ref r0
+    dec_ref head_length :: int
+    dec_ref r52
+    goto L49
+L71:
+    dec_ref r0
+    dec_ref r1
+    dec_ref head_length :: int
+    dec_ref r52
+    dec_ref r76
+    goto L54
+L72:
+    dec_ref r0
+    dec_ref r1
+    dec_ref head_length :: int
+    dec_ref r52
+    dec_ref r76
+    dec_ref r90
+    goto L54
+L73:
+    dec_ref r90
+    goto L43
+L74:
+    dec_ref r96 :: int
+    goto L45
+L75:
+    dec_ref r1
+    goto L54
+L76:
+    dec_ref r109
+    goto L54
+
+def encode_fixed(value, encode_fn, is_big_endian, data_byte_size):
+    value, encode_fn :: object
+    is_big_endian :: bool
+    data_byte_size :: int
+    r0 :: object[1]
+    r1 :: object_ptr
+    r2 :: object
+    r3, r4 :: bytes
+    r5 :: str
+    r6 :: object
+    r7 :: object[3]
+    r8 :: object_ptr
+    r9 :: object
+    r10, r11 :: bytes
+    r12 :: str
+    r13 :: object
+    r14 :: object[3]
+    r15 :: object_ptr
+    r16 :: object
+    r17, r18 :: bytes
+L0:
+    r0 = [value]
+    r1 = load_address r0
+    r2 = PyObject_Vectorcall(encode_fn, r1, 1, 0)
+    if is_error(r2) goto L9 (error at encode_fixed:55) else goto L1
+L1:
+    r3 = cast(bytes, r2)
+    if is_error(r3) goto L9 (error at encode_fixed:55) else goto L2
+L2:
+    if is_big_endian goto L3 else goto L6 :: bool
+L3:
+    r4 = b'\x00'
+    r5 = 'rjust'
+    inc_ref data_byte_size :: int
+    r6 = box(int, data_byte_size)
+    r7 = [r3, r6, r4]
+    r8 = load_address r7
+    r9 = PyObject_VectorcallMethod(r5, r8, 9223372036854775811, 0)
+    if is_error(r9) goto L10 (error at encode_fixed:57) else goto L4
+L4:
+    dec_ref r3
+    dec_ref r6
+    r10 = cast(bytes, r9)
+    if is_error(r10) goto L9 (error at encode_fixed:57) else goto L5
+L5:
+    return r10
+L6:
+    r11 = b'\x00'
+    r12 = 'ljust'
+    inc_ref data_byte_size :: int
+    r13 = box(int, data_byte_size)
+    r14 = [r3, r13, r11]
+    r15 = load_address r14
+    r16 = PyObject_VectorcallMethod(r12, r15, 9223372036854775811, 0)
+    if is_error(r16) goto L11 (error at encode_fixed:59) else goto L7
+L7:
+    dec_ref r3
+    dec_ref r13
+    r17 = cast(bytes, r16)
+    if is_error(r17) goto L9 (error at encode_fixed:59) else goto L8
+L8:
+    return r17
+L9:
+    r18 = <error> :: bytes
+    return r18
+L10:
+    dec_ref r3
+    dec_ref r6
+    goto L9
+L11:
+    dec_ref r3
+    dec_ref r13
+    goto L9
+
+def encode_signed(value, encode_fn, data_byte_size):
+    value, encode_fn :: object
+    data_byte_size :: int
+    r0 :: object[1]
+    r1 :: object_ptr
+    r2 :: object
+    r3 :: bytes
+    r4, r5 :: object
+    r6 :: bool
+    r7 :: bytes
+    r8 :: str
+    r9 :: object
+    r10 :: object[3]
+    r11 :: object_ptr
+    r12 :: object
+    r13, r14 :: bytes
+    r15 :: str
+    r16 :: object
+    r17 :: object[3]
+    r18 :: object_ptr
+    r19 :: object
+    r20, r21 :: bytes
+L0:
+    r0 = [value]
+    r1 = load_address r0
+    r2 = PyObject_Vectorcall(encode_fn, r1, 1, 0)
+    if is_error(r2) goto L11 (error at encode_signed:67) else goto L1
+L1:
+    r3 = cast(bytes, r2)
+    if is_error(r3) goto L11 (error at encode_signed:67) else goto L2
+L2:
+    r4 = object 0
+    r5 = PyObject_RichCompare(value, r4, 5)
+    if is_error(r5) goto L12 (error at encode_signed:68) else goto L3
+L3:
+    r6 = unbox(bool, r5)
+    dec_ref r5
+    if is_error(r6) goto L12 (error at encode_signed:68) else goto L4
+L4:
+    if r6 goto L5 else goto L8 :: bool
+L5:
+    r7 = b'\x00'
+    r8 = 'rjust'
+    inc_ref data_byte_size :: int
+    r9 = box(int, data_byte_size)
+    r10 = [r3, r9, r7]
+    r11 = load_address r10
+    r12 = PyObject_VectorcallMethod(r8, r11, 9223372036854775811, 0)
+    if is_error(r12) goto L13 (error at encode_signed:69) else goto L6
+L6:
+    dec_ref r3
+    dec_ref r9
+    r13 = cast(bytes, r12)
+    if is_error(r13) goto L11 (error at encode_signed:69) else goto L7
+L7:
+    return r13
+L8:
+    r14 = b'\xff'
+    r15 = 'rjust'
+    inc_ref data_byte_size :: int
+    r16 = box(int, data_byte_size)
+    r17 = [r3, r16, r14]
+    r18 = load_address r17
+    r19 = PyObject_VectorcallMethod(r15, r18, 9223372036854775811, 0)
+    if is_error(r19) goto L14 (error at encode_signed:71) else goto L9
+L9:
+    dec_ref r3
+    dec_ref r16
+    r20 = cast(bytes, r19)
+    if is_error(r20) goto L11 (error at encode_signed:71) else goto L10
+L10:
+    return r20
+L11:
+    r21 = <error> :: bytes
+    return r21
+L12:
+    dec_ref r3
+    goto L11
+L13:
+    dec_ref r3
+    dec_ref r9
+    goto L11
+L14:
+    dec_ref r3
+    dec_ref r16
+    goto L11
+
+def encode_elements(item_encoder, value):
+    item_encoder, value :: object
+    r0 :: list
+    r1, r2 :: object
+    r3 :: object[1]
+    r4 :: object_ptr
+    r5 :: object
+    r6 :: bytes
+    r7 :: i32
+    r8, r9 :: bit
+    r10 :: tuple
+    r11 :: str
+    r12, r13 :: object
+    r14 :: bool
+    r15 :: int
+    r16 :: bit
+    r17, r18 :: bytes
+    r19, r20 :: int
+    r21 :: list
+    r22 :: object
+    r23, r24 :: ptr
+    total_offset :: int
+    r25 :: object
+    r26 :: tuple
+    r27 :: ptr
+    r28, r29 :: native_int
+    r30 :: bit
+    r31 :: object
+    r32 :: bytes
+    r33 :: ptr
+    r34 :: native_int
+    r35 :: short_int
+    r36 :: int
+    r37 :: object
+    r38 :: i32
+    r39 :: bit
+    r40 :: native_int
+    r41 :: ptr
+    r42 :: native_int
+    r43 :: tuple
+    r44 :: native_int
+    r45 :: ptr
+    r46 :: native_int
+    r47 :: bit
+    r48, r49 :: ptr
+    r50 :: native_int
+    r51 :: ptr
+    r52 :: object
+    r53, r54 :: int
+    r55 :: bytes
+    r56 :: native_int
+    r57, r58, r59, r60, r61, r62 :: bytes
+L0:
+    r0 = PyList_New(0)
+    if is_error(r0) goto L35 (error at encode_elements:75) else goto L1
+L1:
+    r1 = PyObject_GetIter(value)
+    if is_error(r1) goto L36 (error at encode_elements:75) else goto L2
+L2:
+    r2 = PyIter_Next(r1)
+    if is_error(r2) goto L37 else goto L3
+L3:
+    r3 = [r2]
+    r4 = load_address r3
+    r5 = PyObject_Vectorcall(item_encoder, r4, 1, 0)
+    if is_error(r5) goto L38 (error at encode_elements:75) else goto L4
+L4:
+    dec_ref r2
+    r6 = cast(bytes, r5)
+    if is_error(r6) goto L39 (error at encode_elements:75) else goto L5
+L5:
+    r7 = PyList_Append(r0, r6)
+    dec_ref r6
+    r8 = r7 >= 0 :: signed
+    if not r8 goto L39 (error at encode_elements:75) else goto L2 :: bool
+L6:
+    r9 = CPy_NoErrOccurred()
+    if not r9 goto L36 (error at encode_elements:75) else goto L7 :: bool
+L7:
+    r10 = PyList_AsTuple(r0)
+    dec_ref r0
+    if is_error(r10) goto L35 (error at encode_elements:75) else goto L8
+L8:
+    r11 = 'is_dynamic'
+    r12 = box(bool, 0)
+    r13 = CPyObject_GetAttr3(item_encoder, r11, r12)
+    if is_error(r13) goto L40 (error at encode_elements:77) else goto L9
+L9:
+    r14 = unbox(bool, r13)
+    dec_ref r13
+    if is_error(r14) goto L40 (error at encode_elements:77) else goto L10
+L10:
+    if r14 goto L11 else goto L13 :: bool
+L11:
+    r15 = CPyObject_Size(value)
+    if is_error(r15) goto L40 (error at encode_elements:78) else goto L12
+L12:
+    r16 = r15 == 0
+    dec_ref r15 :: int
+    if r16 goto L13 else goto L15 :: bool
+L13:
+    r17 = b''
+    r18 = CPyBytes_Join(r17, r10)
+    dec_ref r10
+    if is_error(r18) goto L35 (error at encode_elements:79) else goto L14
+L14:
+    return r18
+L15:
+    r19 = CPyObject_Size(value)
+    if is_error(r19) goto L40 (error at encode_elements:81) else goto L16
+L16:
+    r20 = CPyTagged_Multiply(64, r19)
+    dec_ref r19 :: int
+    r21 = PyList_New(1)
+    if is_error(r21) goto L41 (error at encode_elements:82) else goto L17
+L17:
+    r22 = object 0
+    r23 = get_element_ptr r21 ob_item :: PyListObject
+    r24 = load_mem r23 :: ptr*
+    inc_ref r22
+    set_mem r24, r22 :: builtins.object*
+    total_offset = 0
+    r25 = CPySequenceTuple_GetSlice(r10, 0, -2)
+    if is_error(r25) goto L42 (error at encode_elements:84) else goto L18
+L18:
+    r26 = cast(tuple, r25)
+    if is_error(r26) goto L42 (error at encode_elements:84) else goto L19
+L19:
+    r27 = get_element_ptr r26 ob_size :: PyVarObject
+    r28 = load_mem r27 :: native_int*
+    r29 = 0
+L20:
+    r30 = r29 < r28 :: signed
+    if r30 goto L21 else goto L43 :: bool
+L21:
+    r31 = CPySequenceTuple_GetItemUnsafe(r26, r29)
+    r32 = cast(bytes, r31)
+    if is_error(r32) goto L44 (error at encode_elements:84) else goto L22
+L22:
+    r33 = get_element_ptr r32 ob_size :: PyVarObject
+    r34 = load_mem r33 :: native_int*
+    dec_ref r32
+    r35 = r34 << 1
+    r36 = CPyTagged_Add(total_offset, r35)
+    dec_ref total_offset :: int
+    total_offset = r36
+    inc_ref total_offset :: int
+    r37 = box(int, total_offset)
+    r38 = PyList_Append(r21, r37)
+    dec_ref r37
+    r39 = r38 >= 0 :: signed
+    if not r39 goto L44 (error at encode_elements:86) else goto L23 :: bool
+L23:
+    r40 = r29 + 1
+    r29 = r40
+    goto L20
+L24:
+    r41 = get_element_ptr r21 ob_size :: PyVarObject
+    r42 = load_mem r41 :: native_int*
+    r43 = PyTuple_New(r42)
+    if is_error(r43) goto L45 (error at encode_elements:88) else goto L25
+L25:
+    r44 = 0
+L26:
+    r45 = get_element_ptr r21 ob_size :: PyVarObject
+    r46 = load_mem r45 :: native_int*
+    r47 = r44 < r46 :: signed
+    if r47 goto L27 else goto L46 :: bool
+L27:
+    r48 = get_element_ptr r21 ob_item :: PyListObject
+    r49 = load_mem r48 :: ptr*
+    r50 = r44 * 8
+    r51 = r49 + r50
+    r52 = load_mem r51 :: builtins.object*
+    r53 = unbox(int, r52)
+    dec_ref r52
+    if is_error(r53) goto L47 (error at encode_elements:88) else goto L28
+L28:
+    r54 = CPyTagged_Add(r20, r53)
+    dec_ref r53 :: int
+    r55 = encode_uint_256(r54)
+    dec_ref r54 :: int
+    if is_error(r55) goto L47 (error at encode_elements:89) else goto L29
+L29:
+    CPySequenceTuple_SetItemUnsafe(r43, r44, r55)
+L30:
+    r56 = r44 + 1
+    r44 = r56
+    goto L26
+L31:
+    r57 = b''
+    r58 = CPyBytes_Join(r57, r43)
+    dec_ref r43
+    if is_error(r58) goto L40 (error at encode_elements:91) else goto L32
+L32:
+    r59 = b''
+    r60 = CPyBytes_Join(r59, r10)
+    dec_ref r10
+    if is_error(r60) goto L48 (error at encode_elements:91) else goto L33
+L33:
+    r61 = CPyBytes_Concat(r58, r60)
+    dec_ref r60
+    if is_error(r61) goto L35 (error at encode_elements:91) else goto L34
+L34:
+    return r61
+L35:
+    r62 = <error> :: bytes
+    return r62
+L36:
+    dec_ref r0
+    goto L35
+L37:
+    dec_ref r1
+    goto L6
+L38:
+    dec_ref r0
+    dec_ref r1
+    dec_ref r2
+    goto L35
+L39:
+    dec_ref r0
+    dec_ref r1
+    goto L35
+L40:
+    dec_ref r10
+    goto L35
+L41:
+    dec_ref r10
+    dec_ref r20 :: int
+    goto L35
+L42:
+    dec_ref r10
+    dec_ref r20 :: int
+    dec_ref r21
+    dec_ref total_offset :: int
+    goto L35
+L43:
+    dec_ref total_offset :: int
+    dec_ref r26
+    goto L24
+L44:
+    dec_ref r10
+    dec_ref r20 :: int
+    dec_ref r21
+    dec_ref total_offset :: int
+    dec_ref r26
+    goto L35
+L45:
+    dec_ref r10
+    dec_ref r20 :: int
+    dec_ref r21
+    goto L35
+L46:
+    dec_ref r20 :: int
+    dec_ref r21
+    goto L31
+L47:
+    dec_ref r10
+    dec_ref r20 :: int
+    dec_ref r21
+    dec_ref r43
+    goto L35
+L48:
+    dec_ref r58
+    goto L35
+
+def encode_elements_dynamic(item_encoder, value):
+    item_encoder, value :: object
+    r0 :: int
+    r1, r2, r3, r4 :: bytes
+L0:
+    r0 = CPyObject_Size(value)
+    if is_error(r0) goto L5 (error at encode_elements_dynamic:95) else goto L1
+L1:
+    r1 = encode_uint_256(r0)
+    dec_ref r0 :: int
+    if is_error(r1) goto L5 (error at encode_elements_dynamic:95) else goto L2
+L2:
+    r2 = encode_elements(item_encoder, value)
+    if is_error(r2) goto L6 (error at encode_elements_dynamic:96) else goto L3
+L3:
+    r3 = CPyBytes_Concat(r1, r2)
+    dec_ref r2
+    if is_error(r3) goto L5 (error at encode_elements_dynamic:97) else goto L4
+L4:
+    return r3
+L5:
+    r4 = <error> :: bytes
+    return r4
+L6:
+    dec_ref r1
+    goto L5
+
+def encode_uint_256(i):
+    i :: int
+    r0, r1 :: bytes
+    r2 :: str
+    r3 :: object
+    r4 :: object[3]
+    r5 :: object_ptr
+    r6 :: object
+    r7, r8 :: bytes
+L0:
+    r0 = int_to_big_endian(i)
+    if is_error(r0) goto L4 (error at encode_uint_256:104) else goto L1
+L1:
+    r1 = b'\x00'
+    r2 = 'rjust'
+    r3 = object 32
+    r4 = [r0, r3, r1]
+    r5 = load_address r4
+    r6 = PyObject_VectorcallMethod(r2, r5, 9223372036854775811, 0)
+    if is_error(r6) goto L5 (error at encode_uint_256:105) else goto L2
+L2:
+    dec_ref r0
+    r7 = cast(bytes, r6)
+    if is_error(r7) goto L4 (error at encode_uint_256:105) else goto L3
+L3:
+    return r7
+L4:
+    r8 = <error> :: bytes
+    return r8
+L5:
+    dec_ref r0
+    goto L4
+
+def int_to_big_endian(value):
+    value :: int
+    r0 :: str
+    r1 :: object
+    r2 :: object[1]
+    r3 :: object_ptr
+    r4 :: object
+    r5, r6, r7 :: int
+    r8 :: bit
+    r9 :: int
+    r10, r11 :: str
+    r12, r13 :: object
+    r14 :: object[3]
+    r15 :: object_ptr
+    r16 :: object
+    r17, r18 :: bytes
+L0:
+    r0 = 'bit_length'
+    inc_ref value :: int
+    r1 = box(int, value)
+    r2 = [r1]
+    r3 = load_address r2
+    r4 = PyObject_VectorcallMethod(r0, r3, 9223372036854775809, 0)
+    if is_error(r4) goto L10 (error at int_to_big_endian:110) else goto L1
+L1:
+    dec_ref r1
+    r5 = unbox(int, r4)
+    dec_ref r4
+    if is_error(r5) goto L9 (error at int_to_big_endian:110) else goto L2
+L2:
+    r6 = CPyTagged_Add(r5, 14)
+    dec_ref r5 :: int
+    r7 = CPyTagged_Rshift(r6, 6)
+    dec_ref r6 :: int
+    if is_error(r7) goto L9 (error at int_to_big_endian:-1) else goto L3
+L3:
+    r8 = r7 != 0
+    if r8 goto L4 else goto L11 :: bool
+L4:
+    r9 = r7
+    goto L6
+L5:
+    r9 = 2
+L6:
+    r10 = 'big'
+    r11 = 'to_bytes'
+    inc_ref value :: int
+    r12 = box(int, value)
+    r13 = box(int, r9)
+    r14 = [r12, r13, r10]
+    r15 = load_address r14
+    r16 = PyObject_VectorcallMethod(r11, r15, 9223372036854775811, 0)
+    if is_error(r16) goto L12 (error at int_to_big_endian:110) else goto L7
+L7:
+    dec_ref r12
+    dec_ref r13
+    r17 = cast(bytes, r16)
+    if is_error(r17) goto L9 (error at int_to_big_endian:110) else goto L8
+L8:
+    return r17
+L9:
+    r18 = <error> :: bytes
+    return r18
+L10:
+    dec_ref r1
+    goto L9
+L11:
+    dec_ref r7 :: int
+    goto L5
+L12:
+    dec_ref r12
+    dec_ref r13
+    goto L9
+
+def __top_level__():
+    r0, r1 :: object
+    r2 :: bit
+    r3 :: str
+    r4, r5 :: object
+    r6 :: str
+    r7 :: dict
+    r8 :: object
+    r9 :: str
+    r10 :: dict
+    r11 :: str
+    r12 :: object
+    r13 :: object[1]
+    r14 :: object_ptr
+    r15 :: object
+    r16 :: dict
+    r17 :: str
+    r18 :: i32
+    r19 :: bit
+    r20 :: None
+L0:
+    r0 = builtins :: module
+    r1 = load_address _Py_NoneStruct
+    r2 = r0 != r1
+    if r2 goto L3 else goto L1 :: bool
+L1:
+    r3 = 'builtins'
+    r4 = PyImport_Import(r3)
+    if is_error(r4) goto L9 (error at <module>:-1) else goto L2
+L2:
+    builtins = r4 :: module
+    dec_ref r4
+L3:
+    r5 = ('TYPE_CHECKING', 'Any', 'Callable', 'List', 'Optional', 'Sequence', 'TypeVar')
+    r6 = 'typing'
+    r7 = faster_eth_abi._encoding.globals :: static
+    r8 = CPyImport_ImportFromMany(r6, r5, r5, r7)
+    if is_error(r8) goto L9 (error at <module>:1) else goto L4
+L4:
+    typing = r8 :: module
+    dec_ref r8
+    if 0 goto L5 else goto L5 :: bool
+L5:
+    r9 = 'T'
+    r10 = faster_eth_abi._encoding.globals :: static
+    r11 = 'TypeVar'
+    r12 = CPyDict_GetItem(r10, r11)
+    if is_error(r12) goto L9 (error at <module>:17) else goto L6
+L6:
+    r13 = [r9]
+    r14 = load_address r13
+    r15 = PyObject_Vectorcall(r12, r14, 1, 0)
+    dec_ref r12
+    if is_error(r15) goto L9 (error at <module>:17) else goto L7
+L7:
+    r16 = faster_eth_abi._encoding.globals :: static
+    r17 = 'T'
+    r18 = CPyDict_SetItem(r16, r17, r15)
+    dec_ref r15
+    r19 = r18 >= 0 :: signed
+    if not r19 goto L9 (error at <module>:17) else goto L8 :: bool
+L8:
+    return 1
+L9:
+    r20 = <error> :: None
+    return r20
+
 def __top_level__():
     r0, r1 :: object
     r2 :: bit
@@ -4800,216 +5318,6 @@ L4:
 L5:
     r9 = <error> :: None
     return r9
-
-def __top_level__():
-    r0, r1 :: object
-    r2 :: bit
-    r3 :: str
-    r4, r5 :: object
-    r6 :: str
-    r7 :: dict
-    r8, r9 :: object
-    r10 :: str
-    r11 :: dict
-    r12, r13 :: object
-    r14 :: str
-    r15 :: dict
-    r16 :: object
-    r17 :: dict
-    r18 :: str
-    r19 :: object
-    r20 :: dict
-    r21 :: str
-    r22 :: object
-    r23 :: object[1]
-    r24 :: object_ptr
-    r25 :: object
-    r26 :: dict
-    r27 :: str
-    r28 :: i32
-    r29 :: bit
-    r30 :: object
-    r31 :: bool
-    r32 :: str
-    r33 :: object
-    r34 :: dict
-    r35 :: str
-    r36 :: i32
-    r37 :: bit
-    r38 :: object
-    r39 :: bool
-    r40 :: str
-    r41 :: object
-    r42 :: dict
-    r43 :: str
-    r44 :: i32
-    r45 :: bit
-    r46 :: object
-    r47 :: bool
-    r48 :: str
-    r49 :: object
-    r50 :: dict
-    r51 :: str
-    r52 :: i32
-    r53 :: bit
-    r54 :: object
-    r55 :: bool
-    r56 :: str
-    r57 :: object
-    r58 :: dict
-    r59 :: str
-    r60 :: i32
-    r61 :: bit
-    r62 :: None
-L0:
-    r0 = builtins :: module
-    r1 = load_address _Py_NoneStruct
-    r2 = r0 != r1
-    if r2 goto L3 else goto L1 :: bool
-L1:
-    r3 = 'builtins'
-    r4 = PyImport_Import(r3)
-    if is_error(r4) goto L31 (error at <module>:-1) else goto L2
-L2:
-    builtins = r4 :: module
-    dec_ref r4
-L3:
-    r5 = ('Final',)
-    r6 = 'typing'
-    r7 = faster_eth_abi.abi.globals :: static
-    r8 = CPyImport_ImportFromMany(r6, r5, r5, r7)
-    if is_error(r8) goto L31 (error at <module>:1) else goto L4
-L4:
-    typing = r8 :: module
-    dec_ref r8
-    r9 = ('ABICodec',)
-    r10 = 'faster_eth_abi.codec'
-    r11 = faster_eth_abi.abi.globals :: static
-    r12 = CPyImport_ImportFromMany(r10, r9, r9, r11)
-    if is_error(r12) goto L31 (error at <module>:5) else goto L5
-L5:
-    faster_eth_abi.codec = r12 :: module
-    dec_ref r12
-    r13 = ('registry',)
-    r14 = 'faster_eth_abi.registry'
-    r15 = faster_eth_abi.abi.globals :: static
-    r16 = CPyImport_ImportFromMany(r14, r13, r13, r15)
-    if is_error(r16) goto L31 (error at <module>:8) else goto L6
-L6:
-    faster_eth_abi.registry = r16 :: module
-    dec_ref r16
-    r17 = faster_eth_abi.abi.globals :: static
-    r18 = 'registry'
-    r19 = CPyDict_GetItem(r17, r18)
-    if is_error(r19) goto L31 (error at <module>:12) else goto L7
-L7:
-    r20 = faster_eth_abi.abi.globals :: static
-    r21 = 'ABICodec'
-    r22 = CPyDict_GetItem(r20, r21)
-    if is_error(r22) goto L32 (error at <module>:12) else goto L8
-L8:
-    r23 = [r19]
-    r24 = load_address r23
-    r25 = PyObject_Vectorcall(r22, r24, 1, 0)
-    dec_ref r22
-    if is_error(r25) goto L32 (error at <module>:12) else goto L9
-L9:
-    dec_ref r19
-    faster_eth_abi.abi.default_codec = r25 :: static
-    r26 = faster_eth_abi.abi.globals :: static
-    r27 = 'default_codec'
-    r28 = CPyDict_SetItem(r26, r27, r25)
-    dec_ref r25
-    r29 = r28 >= 0 :: signed
-    if not r29 goto L31 (error at <module>:12) else goto L10 :: bool
-L10:
-    r30 = faster_eth_abi.abi.default_codec :: static
-    if is_error(r30) goto L11 else goto L13
-L11:
-    r31 = raise NameError('value for final name "default_codec" was not set')
-    if not r31 goto L31 (error at <module>:14) else goto L12 :: bool
-L12:
-    unreachable
-L13:
-    r32 = 'encode'
-    r33 = CPyObject_GetAttr(r30, r32)
-    if is_error(r33) goto L31 (error at <module>:14) else goto L14
-L14:
-    faster_eth_abi.abi.encode = r33 :: static
-    r34 = faster_eth_abi.abi.globals :: static
-    r35 = 'encode'
-    r36 = CPyDict_SetItem(r34, r35, r33)
-    dec_ref r33
-    r37 = r36 >= 0 :: signed
-    if not r37 goto L31 (error at <module>:14) else goto L15 :: bool
-L15:
-    r38 = faster_eth_abi.abi.default_codec :: static
-    if is_error(r38) goto L16 else goto L18
-L16:
-    r39 = raise NameError('value for final name "default_codec" was not set')
-    if not r39 goto L31 (error at <module>:15) else goto L17 :: bool
-L17:
-    unreachable
-L18:
-    r40 = 'decode'
-    r41 = CPyObject_GetAttr(r38, r40)
-    if is_error(r41) goto L31 (error at <module>:15) else goto L19
-L19:
-    faster_eth_abi.abi.decode = r41 :: static
-    r42 = faster_eth_abi.abi.globals :: static
-    r43 = 'decode'
-    r44 = CPyDict_SetItem(r42, r43, r41)
-    dec_ref r41
-    r45 = r44 >= 0 :: signed
-    if not r45 goto L31 (error at <module>:15) else goto L20 :: bool
-L20:
-    r46 = faster_eth_abi.abi.default_codec :: static
-    if is_error(r46) goto L21 else goto L23
-L21:
-    r47 = raise NameError('value for final name "default_codec" was not set')
-    if not r47 goto L31 (error at <module>:16) else goto L22 :: bool
-L22:
-    unreachable
-L23:
-    r48 = 'is_encodable'
-    r49 = CPyObject_GetAttr(r46, r48)
-    if is_error(r49) goto L31 (error at <module>:16) else goto L24
-L24:
-    faster_eth_abi.abi.is_encodable = r49 :: static
-    r50 = faster_eth_abi.abi.globals :: static
-    r51 = 'is_encodable'
-    r52 = CPyDict_SetItem(r50, r51, r49)
-    dec_ref r49
-    r53 = r52 >= 0 :: signed
-    if not r53 goto L31 (error at <module>:16) else goto L25 :: bool
-L25:
-    r54 = faster_eth_abi.abi.default_codec :: static
-    if is_error(r54) goto L26 else goto L28
-L26:
-    r55 = raise NameError('value for final name "default_codec" was not set')
-    if not r55 goto L31 (error at <module>:17) else goto L27 :: bool
-L27:
-    unreachable
-L28:
-    r56 = 'is_encodable_type'
-    r57 = CPyObject_GetAttr(r54, r56)
-    if is_error(r57) goto L31 (error at <module>:17) else goto L29
-L29:
-    faster_eth_abi.abi.is_encodable_type = r57 :: static
-    r58 = faster_eth_abi.abi.globals :: static
-    r59 = 'is_encodable_type'
-    r60 = CPyDict_SetItem(r58, r59, r57)
-    dec_ref r57
-    r61 = r60 >= 0 :: signed
-    if not r61 goto L31 (error at <module>:17) else goto L30 :: bool
-L30:
-    return 1
-L31:
-    r62 = <error> :: None
-    return r62
-L32:
-    dec_ref r19
-    goto L31
 
 def __top_level__():
     r0, r1 :: object
@@ -5093,6 +5401,135 @@ L7:
 L8:
     r27 = <error> :: None
     return r27
+
+def zpad(value, length):
+    value :: bytes
+    length :: int
+    r0 :: bytes
+    r1 :: str
+    r2 :: object
+    r3 :: object[3]
+    r4 :: object_ptr
+    r5 :: object
+    r6, r7 :: bytes
+L0:
+    r0 = b'\x00'
+    r1 = 'rjust'
+    inc_ref length :: int
+    r2 = box(int, length)
+    r3 = [value, r2, r0]
+    r4 = load_address r3
+    r5 = PyObject_VectorcallMethod(r1, r4, 9223372036854775811, 0)
+    if is_error(r5) goto L4 (error at zpad:2) else goto L1
+L1:
+    dec_ref r2
+    r6 = cast(bytes, r5)
+    if is_error(r6) goto L3 (error at zpad:2) else goto L2
+L2:
+    return r6
+L3:
+    r7 = <error> :: bytes
+    return r7
+L4:
+    dec_ref r2
+    goto L3
+
+def zpad32(value):
+    value, r0, r1 :: bytes
+L0:
+    r0 = zpad(value, 64)
+    if is_error(r0) goto L2 (error at zpad32:6) else goto L1
+L1:
+    return r0
+L2:
+    r1 = <error> :: bytes
+    return r1
+
+def zpad_right(value, length):
+    value :: bytes
+    length :: int
+    r0 :: bytes
+    r1 :: str
+    r2 :: object
+    r3 :: object[3]
+    r4 :: object_ptr
+    r5 :: object
+    r6, r7 :: bytes
+L0:
+    r0 = b'\x00'
+    r1 = 'ljust'
+    inc_ref length :: int
+    r2 = box(int, length)
+    r3 = [value, r2, r0]
+    r4 = load_address r3
+    r5 = PyObject_VectorcallMethod(r1, r4, 9223372036854775811, 0)
+    if is_error(r5) goto L4 (error at zpad_right:10) else goto L1
+L1:
+    dec_ref r2
+    r6 = cast(bytes, r5)
+    if is_error(r6) goto L3 (error at zpad_right:10) else goto L2
+L2:
+    return r6
+L3:
+    r7 = <error> :: bytes
+    return r7
+L4:
+    dec_ref r2
+    goto L3
+
+def zpad32_right(value):
+    value, r0, r1 :: bytes
+L0:
+    r0 = zpad_right(value, 64)
+    if is_error(r0) goto L2 (error at zpad32_right:14) else goto L1
+L1:
+    return r0
+L2:
+    r1 = <error> :: bytes
+    return r1
+
+def fpad(value, length):
+    value :: bytes
+    length :: int
+    r0 :: bytes
+    r1 :: str
+    r2 :: object
+    r3 :: object[3]
+    r4 :: object_ptr
+    r5 :: object
+    r6, r7 :: bytes
+L0:
+    r0 = b'\xff'
+    r1 = 'rjust'
+    inc_ref length :: int
+    r2 = box(int, length)
+    r3 = [value, r2, r0]
+    r4 = load_address r3
+    r5 = PyObject_VectorcallMethod(r1, r4, 9223372036854775811, 0)
+    if is_error(r5) goto L4 (error at fpad:18) else goto L1
+L1:
+    dec_ref r2
+    r6 = cast(bytes, r5)
+    if is_error(r6) goto L3 (error at fpad:18) else goto L2
+L2:
+    return r6
+L3:
+    r7 = <error> :: bytes
+    return r7
+L4:
+    dec_ref r2
+    goto L3
+
+def fpad32(value):
+    value, r0, r1 :: bytes
+L0:
+    r0 = fpad(value, 64)
+    if is_error(r0) goto L2 (error at fpad32:22) else goto L1
+L1:
+    return r0
+L2:
+    r1 = <error> :: bytes
+    return r1
 
 def __top_level__():
     r0, r1 :: object
@@ -6501,6 +6938,394 @@ L40:
     dec_ref r81
     goto L30
 
+def encode_c(self, types, args):
+    self, types, args :: object
+    r0 :: str
+    r1 :: None
+    r2 :: str
+    r3 :: None
+    r4 :: str
+    r5 :: object
+    r6 :: str
+    r7 :: object
+    r8 :: tuple
+    r9 :: object
+    r10 :: object[1]
+    r11 :: object_ptr
+    r12 :: object
+    r13, r14 :: bytes
+L0:
+    r0 = 'types'
+    r1 = validate_list_like_param(types, r0)
+    if is_error(r1) goto L9 (error at encode_c:43) else goto L1
+L1:
+    r2 = 'args'
+    r3 = validate_list_like_param(args, r2)
+    if is_error(r3) goto L9 (error at encode_c:44) else goto L2
+L2:
+    r4 = '_registry'
+    r5 = CPyObject_GetAttr(self, r4)
+    if is_error(r5) goto L9 (error at encode_c:46) else goto L3
+L3:
+    r6 = 'get_tuple_encoder'
+    r7 = CPyObject_GetAttr(r5, r6)
+    dec_ref r5
+    if is_error(r7) goto L9 (error at encode_c:46) else goto L4
+L4:
+    r8 = PySequence_Tuple(types)
+    if is_error(r8) goto L10 (error at encode_c:46) else goto L5
+L5:
+    r9 = PyObject_CallObject(r7, r8)
+    dec_ref r7
+    dec_ref r8
+    if is_error(r9) goto L9 (error at encode_c:46) else goto L6
+L6:
+    r10 = [args]
+    r11 = load_address r10
+    r12 = PyObject_Vectorcall(r9, r11, 1, 0)
+    dec_ref r9
+    if is_error(r12) goto L9 (error at encode_c:48) else goto L7
+L7:
+    r13 = cast(bytes, r12)
+    if is_error(r13) goto L9 (error at encode_c:48) else goto L8
+L8:
+    return r13
+L9:
+    r14 = <error> :: bytes
+    return r14
+L10:
+    dec_ref r7
+    goto L9
+
+def decode_c(self, types, data, strict):
+    self, types :: object
+    data :: union[bytes, object]
+    strict :: bool
+    r0 :: str
+    r1 :: None
+    r2 :: str
+    r3 :: None
+    r4 :: str
+    r5 :: object
+    r6 :: str
+    r7 :: object
+    r8 :: list
+    r9 :: object
+    r10 :: str
+    r11 :: tuple
+    r12 :: object
+    r13 :: dict
+    r14 :: object
+    r15 :: str
+    r16 :: object[2]
+    r17 :: object_ptr
+    r18 :: object
+    r19 :: object[1]
+    r20 :: object_ptr
+    r21 :: object
+    r22, r23 :: tuple
+L0:
+    if is_error(strict) goto L1 else goto L2
+L1:
+    strict = 1
+L2:
+    r0 = 'types'
+    r1 = validate_list_like_param(types, r0)
+    if is_error(r1) goto L15 (error at decode_c:75) else goto L3
+L3:
+    r2 = 'data'
+    r3 = validate_bytes_param(data, r2)
+    if is_error(r3) goto L15 (error at decode_c:76) else goto L4
+L4:
+    r4 = '_registry'
+    r5 = CPyObject_GetAttr(self, r4)
+    if is_error(r5) goto L15 (error at decode_c:78) else goto L5
+L5:
+    r6 = 'get_tuple_decoder'
+    r7 = CPyObject_GetAttr(r5, r6)
+    dec_ref r5
+    if is_error(r7) goto L15 (error at decode_c:78) else goto L6
+L6:
+    r8 = PyList_New(0)
+    if is_error(r8) goto L16 (error at decode_c:78) else goto L7
+L7:
+    r9 = CPyList_Extend(r8, types)
+    if is_error(r9) goto L17 (error at decode_c:78) else goto L18
+L8:
+    r10 = 'strict'
+    r11 = PyList_AsTuple(r8)
+    dec_ref r8
+    if is_error(r11) goto L16 (error at decode_c:78) else goto L9
+L9:
+    r12 = box(bool, strict)
+    r13 = CPyDict_Build(1, r10, r12)
+    if is_error(r13) goto L19 (error at decode_c:78) else goto L10
+L10:
+    r14 = PyObject_Call(r7, r11, r13)
+    dec_ref r7
+    dec_ref r11
+    dec_ref r13
+    if is_error(r14) goto L15 (error at decode_c:78) else goto L11
+L11:
+    r15 = 'stream_class'
+    r16 = [self, data]
+    r17 = load_address r16
+    r18 = PyObject_VectorcallMethod(r15, r17, 9223372036854775810, 0)
+    if is_error(r18) goto L20 (error at decode_c:79) else goto L12
+L12:
+    r19 = [r18]
+    r20 = load_address r19
+    r21 = PyObject_Vectorcall(r14, r20, 1, 0)
+    dec_ref r14
+    if is_error(r21) goto L21 (error at decode_c:81) else goto L13
+L13:
+    dec_ref r18
+    r22 = cast(tuple, r21)
+    if is_error(r22) goto L15 (error at decode_c:81) else goto L14
+L14:
+    return r22
+L15:
+    r23 = <error> :: tuple
+    return r23
+L16:
+    dec_ref r7
+    goto L15
+L17:
+    dec_ref r7
+    dec_ref r8
+    goto L15
+L18:
+    dec_ref r9
+    goto L8
+L19:
+    dec_ref r7
+    dec_ref r11
+    goto L15
+L20:
+    dec_ref r14
+    goto L15
+L21:
+    dec_ref r18
+    goto L15
+
+def __top_level__():
+    r0, r1 :: object
+    r2 :: bit
+    r3 :: str
+    r4, r5 :: object
+    r6 :: str
+    r7 :: dict
+    r8, r9 :: object
+    r10 :: str
+    r11 :: dict
+    r12, r13 :: object
+    r14 :: str
+    r15 :: dict
+    r16 :: object
+    r17 :: None
+L0:
+    r0 = builtins :: module
+    r1 = load_address _Py_NoneStruct
+    r2 = r0 != r1
+    if r2 goto L3 else goto L1 :: bool
+L1:
+    r3 = 'builtins'
+    r4 = PyImport_Import(r3)
+    if is_error(r4) goto L8 (error at <module>:-1) else goto L2
+L2:
+    builtins = r4 :: module
+    dec_ref r4
+L3:
+    r5 = ('TYPE_CHECKING', 'Any', 'Iterable', 'Tuple')
+    r6 = 'typing'
+    r7 = faster_eth_abi._codec.globals :: static
+    r8 = CPyImport_ImportFromMany(r6, r5, r5, r7)
+    if is_error(r8) goto L8 (error at <module>:1) else goto L4
+L4:
+    typing = r8 :: module
+    dec_ref r8
+    r9 = ('Decodable', 'TypeStr')
+    r10 = 'eth_typing'
+    r11 = faster_eth_abi._codec.globals :: static
+    r12 = CPyImport_ImportFromMany(r10, r9, r9, r11)
+    if is_error(r12) goto L8 (error at <module>:8) else goto L5
+L5:
+    eth_typing = r12 :: module
+    dec_ref r12
+    r13 = ('validate_bytes_param', 'validate_list_like_param')
+    r14 = 'faster_eth_abi.utils.validation'
+    r15 = faster_eth_abi._codec.globals :: static
+    r16 = CPyImport_ImportFromMany(r14, r13, r13, r15)
+    if is_error(r16) goto L8 (error at <module>:13) else goto L6
+L6:
+    faster_eth_abi.utils.validation = r16 :: module
+    dec_ref r16
+    if 0 goto L7 else goto L7 :: bool
+L7:
+    return 1
+L8:
+    r17 = <error> :: None
+    return r17
+
+def abbr(value, limit):
+    value :: object
+    limit :: int
+    r0, rep :: str
+    r1 :: native_int
+    r2 :: bit
+    r3 :: short_int
+    r4 :: native_int
+    r5 :: bit
+    r6 :: native_int
+    r7, r8, r9 :: bit
+    r10 :: native_int
+    r11 :: bit
+    r12 :: native_int
+    r13, r14, r15 :: bit
+    r16 :: str
+    r17 :: object
+    r18 :: str
+    r19 :: object
+    r20 :: object[1]
+    r21 :: object_ptr
+    r22 :: object
+    r23 :: int
+    r24 :: object
+    r25, r26, r27, r28 :: str
+L0:
+    if is_error(limit) goto L1 else goto L22
+L1:
+    limit = 158
+L2:
+    r0 = PyObject_Repr(value)
+    if is_error(r0) goto L23 (error at abbr:11) else goto L3
+L3:
+    rep = r0
+    r1 = CPyStr_Size_size_t(rep)
+    r2 = r1 >= 0 :: signed
+    if not r2 goto L24 (error at abbr:13) else goto L4 :: bool
+L4:
+    r3 = r1 << 1
+    r4 = r3 & 1
+    r5 = r4 != 0
+    if r5 goto L6 else goto L5 :: bool
+L5:
+    r6 = limit & 1
+    r7 = r6 != 0
+    if r7 goto L6 else goto L7 :: bool
+L6:
+    r8 = CPyTagged_IsLt_(limit, r3)
+    if r8 goto L8 else goto L25 :: bool
+L7:
+    r9 = r3 > limit :: signed
+    if r9 goto L8 else goto L25 :: bool
+L8:
+    r10 = limit & 1
+    r11 = r10 != 0
+    if r11 goto L10 else goto L9 :: bool
+L9:
+    r12 = 6 & 1
+    r13 = r12 != 0
+    if r13 goto L10 else goto L11 :: bool
+L10:
+    r14 = CPyTagged_IsLt_(limit, 6)
+    if r14 goto L26 else goto L16 :: bool
+L11:
+    r15 = limit < 6 :: signed
+    if r15 goto L26 else goto L16 :: bool
+L12:
+    r16 = 'Abbreviation limit may not be less than 3'
+    r17 = builtins :: module
+    r18 = 'ValueError'
+    r19 = CPyObject_GetAttr(r17, r18)
+    if is_error(r19) goto L21 (error at abbr:15) else goto L13
+L13:
+    r20 = [r16]
+    r21 = load_address r20
+    r22 = PyObject_Vectorcall(r19, r21, 1, 0)
+    dec_ref r19
+    if is_error(r22) goto L21 (error at abbr:15) else goto L14
+L14:
+    CPy_Raise(r22)
+    dec_ref r22
+    if not 0 goto L21 (error at abbr:15) else goto L15 :: bool
+L15:
+    unreachable
+L16:
+    r23 = CPyTagged_Subtract(limit, 6)
+    dec_ref limit :: int
+    r24 = CPyStr_GetSlice(rep, 0, r23)
+    dec_ref rep
+    dec_ref r23 :: int
+    if is_error(r24) goto L21 (error at abbr:17) else goto L17
+L17:
+    r25 = cast(str, r24)
+    if is_error(r25) goto L21 (error at abbr:17) else goto L18
+L18:
+    r26 = '...'
+    r27 = PyUnicode_Concat(r25, r26)
+    dec_ref r25
+    if is_error(r27) goto L21 (error at abbr:17) else goto L19
+L19:
+    rep = r27
+L20:
+    return rep
+L21:
+    r28 = <error> :: str
+    return r28
+L22:
+    inc_ref limit :: int
+    goto L2
+L23:
+    dec_ref limit :: int
+    goto L21
+L24:
+    dec_ref limit :: int
+    dec_ref rep
+    goto L21
+L25:
+    dec_ref limit :: int
+    goto L20
+L26:
+    dec_ref limit :: int
+    dec_ref rep
+    goto L12
+
+def __top_level__():
+    r0, r1 :: object
+    r2 :: bit
+    r3 :: str
+    r4, r5 :: object
+    r6 :: str
+    r7 :: dict
+    r8 :: object
+    r9 :: None
+L0:
+    r0 = builtins :: module
+    r1 = load_address _Py_NoneStruct
+    r2 = r0 != r1
+    if r2 goto L3 else goto L1 :: bool
+L1:
+    r3 = 'builtins'
+    r4 = PyImport_Import(r3)
+    if is_error(r4) goto L5 (error at <module>:-1) else goto L2
+L2:
+    builtins = r4 :: module
+    dec_ref r4
+L3:
+    r5 = ('Any',)
+    r6 = 'typing'
+    r7 = faster_eth_abi.utils.string.globals :: static
+    r8 = CPyImport_ImportFromMany(r6, r5, r5, r7)
+    if is_error(r8) goto L5 (error at <module>:1) else goto L4
+L4:
+    typing = r8 :: module
+    dec_ref r8
+    return 1
+L5:
+    r9 = <error> :: None
+    return r9
+
 def decode_uint_256(stream):
     stream :: object
     r0 :: str
@@ -7702,1208 +8527,66 @@ L9:
     r21 = <error> :: None
     return r21
 
-def abbr(value, limit):
-    value :: object
-    limit :: int
-    r0, rep :: str
-    r1 :: native_int
+def __top_level__():
+    r0, r1 :: object
     r2 :: bit
-    r3 :: short_int
-    r4 :: native_int
-    r5 :: bit
-    r6 :: native_int
-    r7, r8, r9 :: bit
-    r10 :: native_int
-    r11 :: bit
-    r12 :: native_int
-    r13, r14, r15 :: bit
-    r16 :: str
-    r17 :: object
+    r3 :: str
+    r4, r5 :: object
+    r6 :: str
+    r7 :: dict
+    r8, r9 :: object
+    r10 :: str
+    r11 :: dict
+    r12, r13 :: object
+    r14 :: str
+    r15 :: dict
+    r16 :: object
+    r17 :: dict
     r18 :: str
     r19 :: object
-    r20 :: object[1]
-    r21 :: object_ptr
+    r20 :: dict
+    r21 :: str
     r22 :: object
-    r23 :: int
-    r24 :: object
-    r25, r26, r27, r28 :: str
-L0:
-    if is_error(limit) goto L1 else goto L22
-L1:
-    limit = 158
-L2:
-    r0 = PyObject_Repr(value)
-    if is_error(r0) goto L23 (error at abbr:11) else goto L3
-L3:
-    rep = r0
-    r1 = CPyStr_Size_size_t(rep)
-    r2 = r1 >= 0 :: signed
-    if not r2 goto L24 (error at abbr:13) else goto L4 :: bool
-L4:
-    r3 = r1 << 1
-    r4 = r3 & 1
-    r5 = r4 != 0
-    if r5 goto L6 else goto L5 :: bool
-L5:
-    r6 = limit & 1
-    r7 = r6 != 0
-    if r7 goto L6 else goto L7 :: bool
-L6:
-    r8 = CPyTagged_IsLt_(limit, r3)
-    if r8 goto L8 else goto L25 :: bool
-L7:
-    r9 = r3 > limit :: signed
-    if r9 goto L8 else goto L25 :: bool
-L8:
-    r10 = limit & 1
-    r11 = r10 != 0
-    if r11 goto L10 else goto L9 :: bool
-L9:
-    r12 = 6 & 1
-    r13 = r12 != 0
-    if r13 goto L10 else goto L11 :: bool
-L10:
-    r14 = CPyTagged_IsLt_(limit, 6)
-    if r14 goto L26 else goto L16 :: bool
-L11:
-    r15 = limit < 6 :: signed
-    if r15 goto L26 else goto L16 :: bool
-L12:
-    r16 = 'Abbreviation limit may not be less than 3'
-    r17 = builtins :: module
-    r18 = 'ValueError'
-    r19 = CPyObject_GetAttr(r17, r18)
-    if is_error(r19) goto L21 (error at abbr:15) else goto L13
-L13:
-    r20 = [r16]
-    r21 = load_address r20
-    r22 = PyObject_Vectorcall(r19, r21, 1, 0)
-    dec_ref r19
-    if is_error(r22) goto L21 (error at abbr:15) else goto L14
-L14:
-    CPy_Raise(r22)
-    dec_ref r22
-    if not 0 goto L21 (error at abbr:15) else goto L15 :: bool
-L15:
-    unreachable
-L16:
-    r23 = CPyTagged_Subtract(limit, 6)
-    dec_ref limit :: int
-    r24 = CPyStr_GetSlice(rep, 0, r23)
-    dec_ref rep
-    dec_ref r23 :: int
-    if is_error(r24) goto L21 (error at abbr:17) else goto L17
-L17:
-    r25 = cast(str, r24)
-    if is_error(r25) goto L21 (error at abbr:17) else goto L18
-L18:
-    r26 = '...'
-    r27 = PyUnicode_Concat(r25, r26)
-    dec_ref r25
-    if is_error(r27) goto L21 (error at abbr:17) else goto L19
-L19:
-    rep = r27
-L20:
-    return rep
-L21:
-    r28 = <error> :: str
-    return r28
-L22:
-    inc_ref limit :: int
-    goto L2
-L23:
-    dec_ref limit :: int
-    goto L21
-L24:
-    dec_ref limit :: int
-    dec_ref rep
-    goto L21
-L25:
-    dec_ref limit :: int
-    goto L20
-L26:
-    dec_ref limit :: int
-    dec_ref rep
-    goto L12
-
-def __top_level__():
-    r0, r1 :: object
-    r2 :: bit
-    r3 :: str
-    r4, r5 :: object
-    r6 :: str
-    r7 :: dict
-    r8 :: object
-    r9 :: None
-L0:
-    r0 = builtins :: module
-    r1 = load_address _Py_NoneStruct
-    r2 = r0 != r1
-    if r2 goto L3 else goto L1 :: bool
-L1:
-    r3 = 'builtins'
-    r4 = PyImport_Import(r3)
-    if is_error(r4) goto L5 (error at <module>:-1) else goto L2
-L2:
-    builtins = r4 :: module
-    dec_ref r4
-L3:
-    r5 = ('Any',)
-    r6 = 'typing'
-    r7 = faster_eth_abi.utils.string.globals :: static
-    r8 = CPyImport_ImportFromMany(r6, r5, r5, r7)
-    if is_error(r8) goto L5 (error at <module>:1) else goto L4
-L4:
-    typing = r8 :: module
-    dec_ref r8
-    return 1
-L5:
-    r9 = <error> :: None
-    return r9
-
-def encode_tuple(values, encoders):
-    values, encoders :: object
-    r0, r1 :: list
-    r2, r3, r4, r5 :: object
-    r6 :: str
-    r7, r8 :: object
-    r9 :: i32
-    r10 :: bit
-    r11 :: bool
-    r12 :: object
-    r13 :: i32
-    r14 :: bit
-    r15 :: object[1]
-    r16 :: object_ptr
-    r17 :: object
-    r18 :: bytes
-    r19 :: i32
-    r20 :: bit
-    r21 :: object[1]
-    r22 :: object_ptr
-    r23 :: object
-    r24 :: bytes
-    r25 :: i32
-    r26 :: bit
-    r27 :: bytes
-    r28 :: i32
-    r29, r30, r31 :: bit
-    r32 :: int
-    r33 :: native_int
-    r34 :: ptr
-    r35 :: native_int
-    r36 :: bit
-    r37, r38 :: ptr
-    r39 :: native_int
-    r40 :: ptr
-    r41 :: object
-    r42 :: union[bytes, None]
-    r43 :: object
-    r44 :: bit
-    r45 :: int
-    r46 :: bytes
-    r47 :: ptr
-    r48 :: native_int
-    r49 :: short_int
-    r50 :: int
-    r51 :: native_int
-    head_length :: int
-    r52 :: list
-    r53 :: object
-    r54, r55 :: ptr
-    total_offset :: int
-    r56 :: object
-    r57 :: list
-    r58 :: native_int
-    r59 :: ptr
-    r60 :: native_int
-    r61 :: bit
-    r62, r63 :: ptr
-    r64 :: native_int
-    r65 :: ptr
-    r66 :: object
-    r67 :: bytes
-    r68 :: ptr
-    r69 :: native_int
-    r70 :: short_int
-    r71 :: int
-    r72 :: object
-    r73 :: i32
-    r74 :: bit
-    r75 :: native_int
-    r76 :: list
-    r77, r78 :: native_int
-    r79 :: ptr
-    r80 :: native_int
-    r81 :: bit
-    r82 :: ptr
-    r83 :: native_int
-    r84 :: bit
-    r85, r86 :: ptr
-    r87 :: native_int
-    r88 :: ptr
-    r89 :: object
-    r90 :: union[bytes, None]
-    r91, r92 :: ptr
-    r93 :: native_int
-    r94 :: ptr
-    r95 :: object
-    r96 :: int
-    r97 :: object
-    r98 :: bit
-    r99 :: int
-    r100, r101, r102 :: bytes
-    r103 :: i32
-    r104 :: bit
-    r105, r106 :: native_int
-    r107 :: tuple
-    r108, r109, r110, r111, r112, r113 :: bytes
-L0:
-    r0 = PyList_New(0)
-    if is_error(r0) goto L54 (error at encode_tuple:24) else goto L1
-L1:
-    r1 = PyList_New(0)
-    if is_error(r1) goto L55 (error at encode_tuple:25) else goto L2
-L2:
-    r2 = PyObject_GetIter(values)
-    if is_error(r2) goto L56 (error at encode_tuple:26) else goto L3
-L3:
-    r3 = PyObject_GetIter(encoders)
-    if is_error(r3) goto L57 (error at encode_tuple:26) else goto L4
-L4:
-    r4 = PyIter_Next(r2)
-    if is_error(r4) goto L58 else goto L5
-L5:
-    r5 = PyIter_Next(r3)
-    if is_error(r5) goto L59 else goto L6
-L6:
-    r6 = 'is_dynamic'
-    r7 = box(bool, 0)
-    r8 = CPyObject_GetAttr3(r5, r6, r7)
-    if is_error(r8) goto L60 (error at encode_tuple:27) else goto L7
-L7:
-    r9 = PyObject_IsTrue(r8)
-    dec_ref r8
-    r10 = r9 >= 0 :: signed
-    if not r10 goto L60 (error at encode_tuple:27) else goto L8 :: bool
-L8:
-    r11 = truncate r9: i32 to builtins.bool
-    if r11 goto L9 else goto L13 :: bool
-L9:
-    r12 = box(None, 1)
-    r13 = PyList_Append(r0, r12)
-    r14 = r13 >= 0 :: signed
-    if not r14 goto L60 (error at encode_tuple:28) else goto L10 :: bool
-L10:
-    r15 = [r4]
-    r16 = load_address r15
-    r17 = PyObject_Vectorcall(r5, r16, 1, 0)
-    dec_ref r5
-    if is_error(r17) goto L61 (error at encode_tuple:29) else goto L11
-L11:
-    dec_ref r4
-    r18 = cast(bytes, r17)
-    if is_error(r18) goto L62 (error at encode_tuple:29) else goto L12
-L12:
-    r19 = PyList_Append(r1, r18)
-    dec_ref r18
-    r20 = r19 >= 0 :: signed
-    if not r20 goto L62 (error at encode_tuple:29) else goto L4 :: bool
-L13:
-    r21 = [r4]
-    r22 = load_address r21
-    r23 = PyObject_Vectorcall(r5, r22, 1, 0)
-    dec_ref r5
-    if is_error(r23) goto L61 (error at encode_tuple:31) else goto L14
-L14:
-    dec_ref r4
-    r24 = cast(bytes, r23)
-    if is_error(r24) goto L62 (error at encode_tuple:31) else goto L15
-L15:
-    r25 = PyList_Append(r0, r24)
-    dec_ref r24
-    r26 = r25 >= 0 :: signed
-    if not r26 goto L62 (error at encode_tuple:31) else goto L16 :: bool
-L16:
-    r27 = b''
-    r28 = PyList_Append(r1, r27)
-    r29 = r28 >= 0 :: signed
-    if not r29 goto L62 (error at encode_tuple:32) else goto L4 :: bool
-L17:
-    r30 = CPy_NoErrOccurred()
-    if not r30 goto L56 (error at encode_tuple:26) else goto L18 :: bool
-L18:
-    r31 = CPy_NoErrOccurred()
-    if not r31 goto L56 (error at encode_tuple:26) else goto L19 :: bool
-L19:
-    r32 = 0
-    r33 = 0
-L20:
-    r34 = get_element_ptr r0 ob_size :: PyVarObject
-    r35 = load_mem r34 :: native_int*
-    r36 = r33 < r35 :: signed
-    if r36 goto L21 else goto L28 :: bool
-L21:
-    r37 = get_element_ptr r0 ob_item :: PyListObject
-    r38 = load_mem r37 :: ptr*
-    r39 = r33 * 8
-    r40 = r38 + r39
-    r41 = load_mem r40 :: builtins.object*
-    r42 = cast(union[bytes, None], r41)
-    if is_error(r42) goto L63 (error at encode_tuple:34) else goto L22
-L22:
-    r43 = load_address _Py_NoneStruct
-    r44 = r42 == r43
-    if r44 goto L64 else goto L24 :: bool
-L23:
-    r45 = 64
-    goto L26
-L24:
-    r46 = cast(bytes, r42)
-    if is_error(r46) goto L63 (error at encode_tuple:34) else goto L25
-L25:
-    r47 = get_element_ptr r46 ob_size :: PyVarObject
-    r48 = load_mem r47 :: native_int*
-    dec_ref r46
-    r49 = r48 << 1
-    r45 = r49
-L26:
-    r50 = CPyTagged_Add(r32, r45)
-    dec_ref r32 :: int
-    dec_ref r45 :: int
-    r32 = r50
-L27:
-    r51 = r33 + 1
-    r33 = r51
-    goto L20
-L28:
-    head_length = r32
-    r52 = PyList_New(1)
-    if is_error(r52) goto L65 (error at encode_tuple:35) else goto L29
-L29:
-    r53 = object 0
-    r54 = get_element_ptr r52 ob_item :: PyListObject
-    r55 = load_mem r54 :: ptr*
-    inc_ref r53
-    set_mem r55, r53 :: builtins.object*
-    total_offset = 0
-    r56 = CPyList_GetSlice(r1, 0, -2)
-    if is_error(r56) goto L66 (error at encode_tuple:37) else goto L30
-L30:
-    r57 = cast(list, r56)
-    if is_error(r57) goto L66 (error at encode_tuple:37) else goto L31
-L31:
-    r58 = 0
-L32:
-    r59 = get_element_ptr r57 ob_size :: PyVarObject
-    r60 = load_mem r59 :: native_int*
-    r61 = r58 < r60 :: signed
-    if r61 goto L33 else goto L67 :: bool
-L33:
-    r62 = get_element_ptr r57 ob_item :: PyListObject
-    r63 = load_mem r62 :: ptr*
-    r64 = r58 * 8
-    r65 = r63 + r64
-    r66 = load_mem r65 :: builtins.object*
-    r67 = cast(bytes, r66)
-    if is_error(r67) goto L68 (error at encode_tuple:37) else goto L34
-L34:
-    r68 = get_element_ptr r67 ob_size :: PyVarObject
-    r69 = load_mem r68 :: native_int*
-    dec_ref r67
-    r70 = r69 << 1
-    r71 = CPyTagged_Add(total_offset, r70)
-    dec_ref total_offset :: int
-    total_offset = r71
-    inc_ref total_offset :: int
-    r72 = box(int, total_offset)
-    r73 = PyList_Append(r52, r72)
-    dec_ref r72
-    r74 = r73 >= 0 :: signed
-    if not r74 goto L68 (error at encode_tuple:39) else goto L35 :: bool
-L35:
-    r75 = r58 + 1
-    r58 = r75
-    goto L32
-L36:
-    r76 = PyList_New(0)
-    if is_error(r76) goto L69 (error at encode_tuple:41) else goto L37
-L37:
-    r77 = 0
-    r78 = 0
-L38:
-    r79 = get_element_ptr r0 ob_size :: PyVarObject
-    r80 = load_mem r79 :: native_int*
-    r81 = r77 < r80 :: signed
-    if r81 goto L39 else goto L70 :: bool
-L39:
-    r82 = get_element_ptr r52 ob_size :: PyVarObject
-    r83 = load_mem r82 :: native_int*
-    r84 = r78 < r83 :: signed
-    if r84 goto L40 else goto L70 :: bool
-L40:
-    r85 = get_element_ptr r0 ob_item :: PyListObject
-    r86 = load_mem r85 :: ptr*
-    r87 = r77 * 8
-    r88 = r86 + r87
-    r89 = load_mem r88 :: builtins.object*
-    r90 = cast(union[bytes, None], r89)
-    if is_error(r90) goto L71 (error at encode_tuple:41) else goto L41
-L41:
-    r91 = get_element_ptr r52 ob_item :: PyListObject
-    r92 = load_mem r91 :: ptr*
-    r93 = r78 * 8
-    r94 = r92 + r93
-    r95 = load_mem r94 :: builtins.object*
-    r96 = unbox(int, r95)
-    dec_ref r95
-    if is_error(r96) goto L72 (error at encode_tuple:41) else goto L42
-L42:
-    r97 = load_address _Py_NoneStruct
-    r98 = r90 == r97
-    if r98 goto L73 else goto L74 :: bool
-L43:
-    r99 = CPyTagged_Add(head_length, r96)
-    dec_ref r96 :: int
-    r100 = encode_uint_256(r99)
-    dec_ref r99 :: int
-    if is_error(r100) goto L71 (error at encode_tuple:42) else goto L44
-L44:
-    r101 = r100
-    goto L47
-L45:
-    r102 = cast(bytes, r90)
-    if is_error(r102) goto L71 (error at encode_tuple:42) else goto L46
-L46:
-    r101 = r102
-L47:
-    r103 = PyList_Append(r76, r101)
-    dec_ref r101
-    r104 = r103 >= 0 :: signed
-    if not r104 goto L71 (error at encode_tuple:41) else goto L48 :: bool
-L48:
-    r105 = r77 + 1
-    r77 = r105
-    r106 = r78 + 1
-    r78 = r106
-    goto L38
-L49:
-    r107 = PyList_AsTuple(r76)
-    dec_ref r76
-    if is_error(r107) goto L75 (error at encode_tuple:41) else goto L50
-L50:
-    r108 = b''
-    r109 = CPyBytes_Join(r108, r107)
-    dec_ref r107
-    if is_error(r109) goto L75 (error at encode_tuple:46) else goto L51
-L51:
-    r110 = b''
-    r111 = CPyBytes_Join(r110, r1)
-    dec_ref r1
-    if is_error(r111) goto L76 (error at encode_tuple:46) else goto L52
-L52:
-    r112 = CPyBytes_Concat(r109, r111)
-    dec_ref r111
-    if is_error(r112) goto L54 (error at encode_tuple:46) else goto L53
-L53:
-    return r112
-L54:
-    r113 = <error> :: bytes
-    return r113
-L55:
-    dec_ref r0
-    goto L54
-L56:
-    dec_ref r0
-    dec_ref r1
-    goto L54
-L57:
-    dec_ref r0
-    dec_ref r1
-    dec_ref r2
-    goto L54
-L58:
-    dec_ref r2
-    dec_ref r3
-    goto L17
-L59:
-    dec_ref r2
-    dec_ref r3
-    dec_ref r4
-    goto L17
-L60:
-    dec_ref r0
-    dec_ref r1
-    dec_ref r2
-    dec_ref r3
-    dec_ref r4
-    dec_ref r5
-    goto L54
-L61:
-    dec_ref r0
-    dec_ref r1
-    dec_ref r2
-    dec_ref r3
-    dec_ref r4
-    goto L54
-L62:
-    dec_ref r0
-    dec_ref r1
-    dec_ref r2
-    dec_ref r3
-    goto L54
-L63:
-    dec_ref r0
-    dec_ref r1
-    dec_ref r32 :: int
-    goto L54
-L64:
-    dec_ref r42
-    goto L23
-L65:
-    dec_ref r0
-    dec_ref r1
-    dec_ref head_length :: int
-    goto L54
-L66:
-    dec_ref r0
-    dec_ref r1
-    dec_ref head_length :: int
-    dec_ref r52
-    dec_ref total_offset :: int
-    goto L54
-L67:
-    dec_ref total_offset :: int
-    dec_ref r57
-    goto L36
-L68:
-    dec_ref r0
-    dec_ref r1
-    dec_ref head_length :: int
-    dec_ref r52
-    dec_ref total_offset :: int
-    dec_ref r57
-    goto L54
-L69:
-    dec_ref r0
-    dec_ref r1
-    dec_ref head_length :: int
-    dec_ref r52
-    goto L54
-L70:
-    dec_ref r0
-    dec_ref head_length :: int
-    dec_ref r52
-    goto L49
-L71:
-    dec_ref r0
-    dec_ref r1
-    dec_ref head_length :: int
-    dec_ref r52
-    dec_ref r76
-    goto L54
-L72:
-    dec_ref r0
-    dec_ref r1
-    dec_ref head_length :: int
-    dec_ref r52
-    dec_ref r76
-    dec_ref r90
-    goto L54
-L73:
-    dec_ref r90
-    goto L43
-L74:
-    dec_ref r96 :: int
-    goto L45
-L75:
-    dec_ref r1
-    goto L54
-L76:
-    dec_ref r109
-    goto L54
-
-def encode_fixed(value, encode_fn, is_big_endian, data_byte_size):
-    value, encode_fn :: object
-    is_big_endian :: bool
-    data_byte_size :: int
-    r0 :: object[1]
-    r1 :: object_ptr
-    r2 :: object
-    r3, r4 :: bytes
-    r5 :: str
-    r6 :: object
-    r7 :: object[3]
-    r8 :: object_ptr
-    r9 :: object
-    r10, r11 :: bytes
-    r12 :: str
-    r13 :: object
-    r14 :: object[3]
-    r15 :: object_ptr
-    r16 :: object
-    r17, r18 :: bytes
-L0:
-    r0 = [value]
-    r1 = load_address r0
-    r2 = PyObject_Vectorcall(encode_fn, r1, 1, 0)
-    if is_error(r2) goto L9 (error at encode_fixed:55) else goto L1
-L1:
-    r3 = cast(bytes, r2)
-    if is_error(r3) goto L9 (error at encode_fixed:55) else goto L2
-L2:
-    if is_big_endian goto L3 else goto L6 :: bool
-L3:
-    r4 = b'\x00'
-    r5 = 'rjust'
-    inc_ref data_byte_size :: int
-    r6 = box(int, data_byte_size)
-    r7 = [r3, r6, r4]
-    r8 = load_address r7
-    r9 = PyObject_VectorcallMethod(r5, r8, 9223372036854775811, 0)
-    if is_error(r9) goto L10 (error at encode_fixed:57) else goto L4
-L4:
-    dec_ref r3
-    dec_ref r6
-    r10 = cast(bytes, r9)
-    if is_error(r10) goto L9 (error at encode_fixed:57) else goto L5
-L5:
-    return r10
-L6:
-    r11 = b'\x00'
-    r12 = 'ljust'
-    inc_ref data_byte_size :: int
-    r13 = box(int, data_byte_size)
-    r14 = [r3, r13, r11]
-    r15 = load_address r14
-    r16 = PyObject_VectorcallMethod(r12, r15, 9223372036854775811, 0)
-    if is_error(r16) goto L11 (error at encode_fixed:59) else goto L7
-L7:
-    dec_ref r3
-    dec_ref r13
-    r17 = cast(bytes, r16)
-    if is_error(r17) goto L9 (error at encode_fixed:59) else goto L8
-L8:
-    return r17
-L9:
-    r18 = <error> :: bytes
-    return r18
-L10:
-    dec_ref r3
-    dec_ref r6
-    goto L9
-L11:
-    dec_ref r3
-    dec_ref r13
-    goto L9
-
-def encode_signed(value, encode_fn, data_byte_size):
-    value, encode_fn :: object
-    data_byte_size :: int
-    r0 :: object[1]
-    r1 :: object_ptr
-    r2 :: object
-    r3 :: bytes
-    r4, r5 :: object
-    r6 :: bool
-    r7 :: bytes
-    r8 :: str
-    r9 :: object
-    r10 :: object[3]
-    r11 :: object_ptr
-    r12 :: object
-    r13, r14 :: bytes
-    r15 :: str
-    r16 :: object
-    r17 :: object[3]
-    r18 :: object_ptr
-    r19 :: object
-    r20, r21 :: bytes
-L0:
-    r0 = [value]
-    r1 = load_address r0
-    r2 = PyObject_Vectorcall(encode_fn, r1, 1, 0)
-    if is_error(r2) goto L11 (error at encode_signed:67) else goto L1
-L1:
-    r3 = cast(bytes, r2)
-    if is_error(r3) goto L11 (error at encode_signed:67) else goto L2
-L2:
-    r4 = object 0
-    r5 = PyObject_RichCompare(value, r4, 5)
-    if is_error(r5) goto L12 (error at encode_signed:68) else goto L3
-L3:
-    r6 = unbox(bool, r5)
-    dec_ref r5
-    if is_error(r6) goto L12 (error at encode_signed:68) else goto L4
-L4:
-    if r6 goto L5 else goto L8 :: bool
-L5:
-    r7 = b'\x00'
-    r8 = 'rjust'
-    inc_ref data_byte_size :: int
-    r9 = box(int, data_byte_size)
-    r10 = [r3, r9, r7]
-    r11 = load_address r10
-    r12 = PyObject_VectorcallMethod(r8, r11, 9223372036854775811, 0)
-    if is_error(r12) goto L13 (error at encode_signed:69) else goto L6
-L6:
-    dec_ref r3
-    dec_ref r9
-    r13 = cast(bytes, r12)
-    if is_error(r13) goto L11 (error at encode_signed:69) else goto L7
-L7:
-    return r13
-L8:
-    r14 = b'\xff'
-    r15 = 'rjust'
-    inc_ref data_byte_size :: int
-    r16 = box(int, data_byte_size)
-    r17 = [r3, r16, r14]
-    r18 = load_address r17
-    r19 = PyObject_VectorcallMethod(r15, r18, 9223372036854775811, 0)
-    if is_error(r19) goto L14 (error at encode_signed:71) else goto L9
-L9:
-    dec_ref r3
-    dec_ref r16
-    r20 = cast(bytes, r19)
-    if is_error(r20) goto L11 (error at encode_signed:71) else goto L10
-L10:
-    return r20
-L11:
-    r21 = <error> :: bytes
-    return r21
-L12:
-    dec_ref r3
-    goto L11
-L13:
-    dec_ref r3
-    dec_ref r9
-    goto L11
-L14:
-    dec_ref r3
-    dec_ref r16
-    goto L11
-
-def encode_elements(item_encoder, value):
-    item_encoder, value :: object
-    r0 :: list
-    r1, r2 :: object
-    r3 :: object[1]
-    r4 :: object_ptr
-    r5 :: object
-    r6 :: bytes
-    r7 :: i32
-    r8, r9 :: bit
-    r10 :: tuple
-    r11 :: str
-    r12, r13 :: object
-    r14 :: bool
-    r15 :: int
-    r16 :: bit
-    r17, r18 :: bytes
-    r19, r20 :: int
-    r21 :: list
-    r22 :: object
-    r23, r24 :: ptr
-    total_offset :: int
+    r23 :: object[1]
+    r24 :: object_ptr
     r25 :: object
-    r26 :: tuple
-    r27 :: ptr
-    r28, r29 :: native_int
-    r30 :: bit
-    r31 :: object
-    r32 :: bytes
-    r33 :: ptr
-    r34 :: native_int
-    r35 :: short_int
-    r36 :: int
-    r37 :: object
-    r38 :: i32
-    r39 :: bit
-    r40 :: native_int
-    r41 :: ptr
-    r42 :: native_int
-    r43 :: tuple
-    r44 :: native_int
-    r45 :: ptr
-    r46 :: native_int
-    r47 :: bit
-    r48, r49 :: ptr
-    r50 :: native_int
-    r51 :: ptr
-    r52 :: object
-    r53, r54 :: int
-    r55 :: bytes
-    r56 :: native_int
-    r57, r58, r59, r60, r61, r62 :: bytes
-L0:
-    r0 = PyList_New(0)
-    if is_error(r0) goto L35 (error at encode_elements:75) else goto L1
-L1:
-    r1 = PyObject_GetIter(value)
-    if is_error(r1) goto L36 (error at encode_elements:75) else goto L2
-L2:
-    r2 = PyIter_Next(r1)
-    if is_error(r2) goto L37 else goto L3
-L3:
-    r3 = [r2]
-    r4 = load_address r3
-    r5 = PyObject_Vectorcall(item_encoder, r4, 1, 0)
-    if is_error(r5) goto L38 (error at encode_elements:75) else goto L4
-L4:
-    dec_ref r2
-    r6 = cast(bytes, r5)
-    if is_error(r6) goto L39 (error at encode_elements:75) else goto L5
-L5:
-    r7 = PyList_Append(r0, r6)
-    dec_ref r6
-    r8 = r7 >= 0 :: signed
-    if not r8 goto L39 (error at encode_elements:75) else goto L2 :: bool
-L6:
-    r9 = CPy_NoErrOccurred()
-    if not r9 goto L36 (error at encode_elements:75) else goto L7 :: bool
-L7:
-    r10 = PyList_AsTuple(r0)
-    dec_ref r0
-    if is_error(r10) goto L35 (error at encode_elements:75) else goto L8
-L8:
-    r11 = 'is_dynamic'
-    r12 = box(bool, 0)
-    r13 = CPyObject_GetAttr3(item_encoder, r11, r12)
-    if is_error(r13) goto L40 (error at encode_elements:77) else goto L9
-L9:
-    r14 = unbox(bool, r13)
-    dec_ref r13
-    if is_error(r14) goto L40 (error at encode_elements:77) else goto L10
-L10:
-    if r14 goto L11 else goto L13 :: bool
-L11:
-    r15 = CPyObject_Size(value)
-    if is_error(r15) goto L40 (error at encode_elements:78) else goto L12
-L12:
-    r16 = r15 == 0
-    dec_ref r15 :: int
-    if r16 goto L13 else goto L15 :: bool
-L13:
-    r17 = b''
-    r18 = CPyBytes_Join(r17, r10)
-    dec_ref r10
-    if is_error(r18) goto L35 (error at encode_elements:79) else goto L14
-L14:
-    return r18
-L15:
-    r19 = CPyObject_Size(value)
-    if is_error(r19) goto L40 (error at encode_elements:81) else goto L16
-L16:
-    r20 = CPyTagged_Multiply(64, r19)
-    dec_ref r19 :: int
-    r21 = PyList_New(1)
-    if is_error(r21) goto L41 (error at encode_elements:82) else goto L17
-L17:
-    r22 = object 0
-    r23 = get_element_ptr r21 ob_item :: PyListObject
-    r24 = load_mem r23 :: ptr*
-    inc_ref r22
-    set_mem r24, r22 :: builtins.object*
-    total_offset = 0
-    r25 = CPySequenceTuple_GetSlice(r10, 0, -2)
-    if is_error(r25) goto L42 (error at encode_elements:84) else goto L18
-L18:
-    r26 = cast(tuple, r25)
-    if is_error(r26) goto L42 (error at encode_elements:84) else goto L19
-L19:
-    r27 = get_element_ptr r26 ob_size :: PyVarObject
-    r28 = load_mem r27 :: native_int*
-    r29 = 0
-L20:
-    r30 = r29 < r28 :: signed
-    if r30 goto L21 else goto L43 :: bool
-L21:
-    r31 = CPySequenceTuple_GetItemUnsafe(r26, r29)
-    r32 = cast(bytes, r31)
-    if is_error(r32) goto L44 (error at encode_elements:84) else goto L22
-L22:
-    r33 = get_element_ptr r32 ob_size :: PyVarObject
-    r34 = load_mem r33 :: native_int*
-    dec_ref r32
-    r35 = r34 << 1
-    r36 = CPyTagged_Add(total_offset, r35)
-    dec_ref total_offset :: int
-    total_offset = r36
-    inc_ref total_offset :: int
-    r37 = box(int, total_offset)
-    r38 = PyList_Append(r21, r37)
-    dec_ref r37
-    r39 = r38 >= 0 :: signed
-    if not r39 goto L44 (error at encode_elements:86) else goto L23 :: bool
-L23:
-    r40 = r29 + 1
-    r29 = r40
-    goto L20
-L24:
-    r41 = get_element_ptr r21 ob_size :: PyVarObject
-    r42 = load_mem r41 :: native_int*
-    r43 = PyTuple_New(r42)
-    if is_error(r43) goto L45 (error at encode_elements:88) else goto L25
-L25:
-    r44 = 0
-L26:
-    r45 = get_element_ptr r21 ob_size :: PyVarObject
-    r46 = load_mem r45 :: native_int*
-    r47 = r44 < r46 :: signed
-    if r47 goto L27 else goto L46 :: bool
-L27:
-    r48 = get_element_ptr r21 ob_item :: PyListObject
-    r49 = load_mem r48 :: ptr*
-    r50 = r44 * 8
-    r51 = r49 + r50
-    r52 = load_mem r51 :: builtins.object*
-    r53 = unbox(int, r52)
-    dec_ref r52
-    if is_error(r53) goto L47 (error at encode_elements:88) else goto L28
-L28:
-    r54 = CPyTagged_Add(r20, r53)
-    dec_ref r53 :: int
-    r55 = encode_uint_256(r54)
-    dec_ref r54 :: int
-    if is_error(r55) goto L47 (error at encode_elements:89) else goto L29
-L29:
-    CPySequenceTuple_SetItemUnsafe(r43, r44, r55)
-L30:
-    r56 = r44 + 1
-    r44 = r56
-    goto L26
-L31:
-    r57 = b''
-    r58 = CPyBytes_Join(r57, r43)
-    dec_ref r43
-    if is_error(r58) goto L40 (error at encode_elements:91) else goto L32
-L32:
-    r59 = b''
-    r60 = CPyBytes_Join(r59, r10)
-    dec_ref r10
-    if is_error(r60) goto L48 (error at encode_elements:91) else goto L33
-L33:
-    r61 = CPyBytes_Concat(r58, r60)
-    dec_ref r60
-    if is_error(r61) goto L35 (error at encode_elements:91) else goto L34
-L34:
-    return r61
-L35:
-    r62 = <error> :: bytes
-    return r62
-L36:
-    dec_ref r0
-    goto L35
-L37:
-    dec_ref r1
-    goto L6
-L38:
-    dec_ref r0
-    dec_ref r1
-    dec_ref r2
-    goto L35
-L39:
-    dec_ref r0
-    dec_ref r1
-    goto L35
-L40:
-    dec_ref r10
-    goto L35
-L41:
-    dec_ref r10
-    dec_ref r20 :: int
-    goto L35
-L42:
-    dec_ref r10
-    dec_ref r20 :: int
-    dec_ref r21
-    dec_ref total_offset :: int
-    goto L35
-L43:
-    dec_ref total_offset :: int
-    dec_ref r26
-    goto L24
-L44:
-    dec_ref r10
-    dec_ref r20 :: int
-    dec_ref r21
-    dec_ref total_offset :: int
-    dec_ref r26
-    goto L35
-L45:
-    dec_ref r10
-    dec_ref r20 :: int
-    dec_ref r21
-    goto L35
-L46:
-    dec_ref r20 :: int
-    dec_ref r21
-    goto L31
-L47:
-    dec_ref r10
-    dec_ref r20 :: int
-    dec_ref r21
-    dec_ref r43
-    goto L35
-L48:
-    dec_ref r58
-    goto L35
-
-def encode_elements_dynamic(item_encoder, value):
-    item_encoder, value :: object
-    r0 :: int
-    r1, r2, r3, r4 :: bytes
-L0:
-    r0 = CPyObject_Size(value)
-    if is_error(r0) goto L5 (error at encode_elements_dynamic:95) else goto L1
-L1:
-    r1 = encode_uint_256(r0)
-    dec_ref r0 :: int
-    if is_error(r1) goto L5 (error at encode_elements_dynamic:95) else goto L2
-L2:
-    r2 = encode_elements(item_encoder, value)
-    if is_error(r2) goto L6 (error at encode_elements_dynamic:96) else goto L3
-L3:
-    r3 = CPyBytes_Concat(r1, r2)
-    dec_ref r2
-    if is_error(r3) goto L5 (error at encode_elements_dynamic:97) else goto L4
-L4:
-    return r3
-L5:
-    r4 = <error> :: bytes
-    return r4
-L6:
-    dec_ref r1
-    goto L5
-
-def encode_uint_256(i):
-    i :: int
-    r0, r1 :: bytes
-    r2 :: str
-    r3 :: object
-    r4 :: object[3]
-    r5 :: object_ptr
-    r6 :: object
-    r7, r8 :: bytes
-L0:
-    r0 = int_to_big_endian(i)
-    if is_error(r0) goto L4 (error at encode_uint_256:104) else goto L1
-L1:
-    r1 = b'\x00'
-    r2 = 'rjust'
-    r3 = object 32
-    r4 = [r0, r3, r1]
-    r5 = load_address r4
-    r6 = PyObject_VectorcallMethod(r2, r5, 9223372036854775811, 0)
-    if is_error(r6) goto L5 (error at encode_uint_256:105) else goto L2
-L2:
-    dec_ref r0
-    r7 = cast(bytes, r6)
-    if is_error(r7) goto L4 (error at encode_uint_256:105) else goto L3
-L3:
-    return r7
-L4:
-    r8 = <error> :: bytes
-    return r8
-L5:
-    dec_ref r0
-    goto L4
-
-def int_to_big_endian(value):
-    value :: int
-    r0 :: str
-    r1 :: object
-    r2 :: object[1]
-    r3 :: object_ptr
-    r4 :: object
-    r5, r6, r7 :: int
-    r8 :: bit
-    r9 :: int
-    r10, r11 :: str
-    r12, r13 :: object
-    r14 :: object[3]
-    r15 :: object_ptr
-    r16 :: object
-    r17, r18 :: bytes
-L0:
-    r0 = 'bit_length'
-    inc_ref value :: int
-    r1 = box(int, value)
-    r2 = [r1]
-    r3 = load_address r2
-    r4 = PyObject_VectorcallMethod(r0, r3, 9223372036854775809, 0)
-    if is_error(r4) goto L10 (error at int_to_big_endian:110) else goto L1
-L1:
-    dec_ref r1
-    r5 = unbox(int, r4)
-    dec_ref r4
-    if is_error(r5) goto L9 (error at int_to_big_endian:110) else goto L2
-L2:
-    r6 = CPyTagged_Add(r5, 14)
-    dec_ref r5 :: int
-    r7 = CPyTagged_Rshift(r6, 6)
-    dec_ref r6 :: int
-    if is_error(r7) goto L9 (error at int_to_big_endian:-1) else goto L3
-L3:
-    r8 = r7 != 0
-    if r8 goto L4 else goto L11 :: bool
-L4:
-    r9 = r7
-    goto L6
-L5:
-    r9 = 2
-L6:
-    r10 = 'big'
-    r11 = 'to_bytes'
-    inc_ref value :: int
-    r12 = box(int, value)
-    r13 = box(int, r9)
-    r14 = [r12, r13, r10]
-    r15 = load_address r14
-    r16 = PyObject_VectorcallMethod(r11, r15, 9223372036854775811, 0)
-    if is_error(r16) goto L12 (error at int_to_big_endian:110) else goto L7
-L7:
-    dec_ref r12
-    dec_ref r13
-    r17 = cast(bytes, r16)
-    if is_error(r17) goto L9 (error at int_to_big_endian:110) else goto L8
-L8:
-    return r17
-L9:
-    r18 = <error> :: bytes
-    return r18
-L10:
-    dec_ref r1
-    goto L9
-L11:
-    dec_ref r7 :: int
-    goto L5
-L12:
-    dec_ref r12
-    dec_ref r13
-    goto L9
-
-def __top_level__():
-    r0, r1 :: object
-    r2 :: bit
-    r3 :: str
-    r4, r5 :: object
-    r6 :: str
-    r7 :: dict
-    r8 :: object
-    r9 :: str
-    r10 :: dict
-    r11 :: str
-    r12 :: object
-    r13 :: object[1]
-    r14 :: object_ptr
-    r15 :: object
-    r16 :: dict
-    r17 :: str
-    r18 :: i32
-    r19 :: bit
-    r20 :: None
+    r26 :: dict
+    r27 :: str
+    r28 :: i32
+    r29 :: bit
+    r30 :: object
+    r31 :: bool
+    r32 :: str
+    r33 :: object
+    r34 :: dict
+    r35 :: str
+    r36 :: i32
+    r37 :: bit
+    r38 :: object
+    r39 :: bool
+    r40 :: str
+    r41 :: object
+    r42 :: dict
+    r43 :: str
+    r44 :: i32
+    r45 :: bit
+    r46 :: object
+    r47 :: bool
+    r48 :: str
+    r49 :: object
+    r50 :: dict
+    r51 :: str
+    r52 :: i32
+    r53 :: bit
+    r54 :: object
+    r55 :: bool
+    r56 :: str
+    r57 :: object
+    r58 :: dict
+    r59 :: str
+    r60 :: i32
+    r61 :: bit
+    r62 :: None
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -8912,41 +8595,322 @@ L0:
 L1:
     r3 = 'builtins'
     r4 = PyImport_Import(r3)
-    if is_error(r4) goto L9 (error at <module>:-1) else goto L2
+    if is_error(r4) goto L31 (error at <module>:-1) else goto L2
 L2:
     builtins = r4 :: module
     dec_ref r4
 L3:
-    r5 = ('TYPE_CHECKING', 'Any', 'Callable', 'List', 'Optional', 'Sequence', 'TypeVar')
+    r5 = ('Final',)
     r6 = 'typing'
-    r7 = faster_eth_abi._encoding.globals :: static
+    r7 = faster_eth_abi.abi.globals :: static
     r8 = CPyImport_ImportFromMany(r6, r5, r5, r7)
-    if is_error(r8) goto L9 (error at <module>:1) else goto L4
+    if is_error(r8) goto L31 (error at <module>:1) else goto L4
 L4:
     typing = r8 :: module
     dec_ref r8
-    if 0 goto L5 else goto L5 :: bool
+    r9 = ('ABICodec',)
+    r10 = 'faster_eth_abi.codec'
+    r11 = faster_eth_abi.abi.globals :: static
+    r12 = CPyImport_ImportFromMany(r10, r9, r9, r11)
+    if is_error(r12) goto L31 (error at <module>:5) else goto L5
 L5:
-    r9 = 'T'
-    r10 = faster_eth_abi._encoding.globals :: static
-    r11 = 'TypeVar'
-    r12 = CPyDict_GetItem(r10, r11)
-    if is_error(r12) goto L9 (error at <module>:17) else goto L6
-L6:
-    r13 = [r9]
-    r14 = load_address r13
-    r15 = PyObject_Vectorcall(r12, r14, 1, 0)
+    faster_eth_abi.codec = r12 :: module
     dec_ref r12
-    if is_error(r15) goto L9 (error at <module>:17) else goto L7
+    r13 = ('registry',)
+    r14 = 'faster_eth_abi.registry'
+    r15 = faster_eth_abi.abi.globals :: static
+    r16 = CPyImport_ImportFromMany(r14, r13, r13, r15)
+    if is_error(r16) goto L31 (error at <module>:8) else goto L6
+L6:
+    faster_eth_abi.registry = r16 :: module
+    dec_ref r16
+    r17 = faster_eth_abi.abi.globals :: static
+    r18 = 'registry'
+    r19 = CPyDict_GetItem(r17, r18)
+    if is_error(r19) goto L31 (error at <module>:12) else goto L7
 L7:
-    r16 = faster_eth_abi._encoding.globals :: static
-    r17 = 'T'
-    r18 = CPyDict_SetItem(r16, r17, r15)
-    dec_ref r15
-    r19 = r18 >= 0 :: signed
-    if not r19 goto L9 (error at <module>:17) else goto L8 :: bool
+    r20 = faster_eth_abi.abi.globals :: static
+    r21 = 'ABICodec'
+    r22 = CPyDict_GetItem(r20, r21)
+    if is_error(r22) goto L32 (error at <module>:12) else goto L8
 L8:
-    return 1
+    r23 = [r19]
+    r24 = load_address r23
+    r25 = PyObject_Vectorcall(r22, r24, 1, 0)
+    dec_ref r22
+    if is_error(r25) goto L32 (error at <module>:12) else goto L9
 L9:
-    r20 = <error> :: None
-    return r20
+    dec_ref r19
+    faster_eth_abi.abi.default_codec = r25 :: static
+    r26 = faster_eth_abi.abi.globals :: static
+    r27 = 'default_codec'
+    r28 = CPyDict_SetItem(r26, r27, r25)
+    dec_ref r25
+    r29 = r28 >= 0 :: signed
+    if not r29 goto L31 (error at <module>:12) else goto L10 :: bool
+L10:
+    r30 = faster_eth_abi.abi.default_codec :: static
+    if is_error(r30) goto L11 else goto L13
+L11:
+    r31 = raise NameError('value for final name "default_codec" was not set')
+    if not r31 goto L31 (error at <module>:14) else goto L12 :: bool
+L12:
+    unreachable
+L13:
+    r32 = 'encode'
+    r33 = CPyObject_GetAttr(r30, r32)
+    if is_error(r33) goto L31 (error at <module>:14) else goto L14
+L14:
+    faster_eth_abi.abi.encode = r33 :: static
+    r34 = faster_eth_abi.abi.globals :: static
+    r35 = 'encode'
+    r36 = CPyDict_SetItem(r34, r35, r33)
+    dec_ref r33
+    r37 = r36 >= 0 :: signed
+    if not r37 goto L31 (error at <module>:14) else goto L15 :: bool
+L15:
+    r38 = faster_eth_abi.abi.default_codec :: static
+    if is_error(r38) goto L16 else goto L18
+L16:
+    r39 = raise NameError('value for final name "default_codec" was not set')
+    if not r39 goto L31 (error at <module>:15) else goto L17 :: bool
+L17:
+    unreachable
+L18:
+    r40 = 'decode'
+    r41 = CPyObject_GetAttr(r38, r40)
+    if is_error(r41) goto L31 (error at <module>:15) else goto L19
+L19:
+    faster_eth_abi.abi.decode = r41 :: static
+    r42 = faster_eth_abi.abi.globals :: static
+    r43 = 'decode'
+    r44 = CPyDict_SetItem(r42, r43, r41)
+    dec_ref r41
+    r45 = r44 >= 0 :: signed
+    if not r45 goto L31 (error at <module>:15) else goto L20 :: bool
+L20:
+    r46 = faster_eth_abi.abi.default_codec :: static
+    if is_error(r46) goto L21 else goto L23
+L21:
+    r47 = raise NameError('value for final name "default_codec" was not set')
+    if not r47 goto L31 (error at <module>:16) else goto L22 :: bool
+L22:
+    unreachable
+L23:
+    r48 = 'is_encodable'
+    r49 = CPyObject_GetAttr(r46, r48)
+    if is_error(r49) goto L31 (error at <module>:16) else goto L24
+L24:
+    faster_eth_abi.abi.is_encodable = r49 :: static
+    r50 = faster_eth_abi.abi.globals :: static
+    r51 = 'is_encodable'
+    r52 = CPyDict_SetItem(r50, r51, r49)
+    dec_ref r49
+    r53 = r52 >= 0 :: signed
+    if not r53 goto L31 (error at <module>:16) else goto L25 :: bool
+L25:
+    r54 = faster_eth_abi.abi.default_codec :: static
+    if is_error(r54) goto L26 else goto L28
+L26:
+    r55 = raise NameError('value for final name "default_codec" was not set')
+    if not r55 goto L31 (error at <module>:17) else goto L27 :: bool
+L27:
+    unreachable
+L28:
+    r56 = 'is_encodable_type'
+    r57 = CPyObject_GetAttr(r54, r56)
+    if is_error(r57) goto L31 (error at <module>:17) else goto L29
+L29:
+    faster_eth_abi.abi.is_encodable_type = r57 :: static
+    r58 = faster_eth_abi.abi.globals :: static
+    r59 = 'is_encodable_type'
+    r60 = CPyDict_SetItem(r58, r59, r57)
+    dec_ref r57
+    r61 = r60 >= 0 :: signed
+    if not r61 goto L31 (error at <module>:17) else goto L30 :: bool
+L30:
+    return 1
+L31:
+    r62 = <error> :: None
+    return r62
+L32:
+    dec_ref r19
+    goto L31
+
+def __top_level__():
+    r0, r1 :: object
+    r2 :: bit
+    r3 :: str
+    r4 :: object
+    r5 :: None
+L0:
+    r0 = builtins :: module
+    r1 = load_address _Py_NoneStruct
+    r2 = r0 != r1
+    if r2 goto L3 else goto L1 :: bool
+L1:
+    r3 = 'builtins'
+    r4 = PyImport_Import(r3)
+    if is_error(r4) goto L4 (error at <module>:-1) else goto L2
+L2:
+    builtins = r4 :: module
+    dec_ref r4
+L3:
+    return 1
+L4:
+    r5 = <error> :: None
+    return r5
+
+def __top_level__():
+    r0, r1 :: object
+    r2 :: bit
+    r3 :: str
+    r4, r5 :: object
+    r6 :: str
+    r7 :: dict
+    r8, r9 :: object
+    r10 :: str
+    r11 :: dict
+    r12, r13 :: object
+    r14 :: str
+    r15 :: dict
+    r16 :: object
+    r17 :: dict
+    r18 :: str
+    r19 :: object
+    r20 :: dict
+    r21 :: str
+    r22 :: object
+    r23 :: object[1]
+    r24 :: object_ptr
+    r25 :: object
+    r26 :: dict
+    r27 :: str
+    r28 :: i32
+    r29 :: bit
+    r30 :: object
+    r31 :: bool
+    r32 :: str
+    r33 :: object
+    r34 :: dict
+    r35 :: str
+    r36 :: i32
+    r37 :: bit
+    r38 :: object
+    r39 :: bool
+    r40 :: str
+    r41 :: object
+    r42 :: dict
+    r43 :: str
+    r44 :: i32
+    r45 :: bit
+    r46 :: None
+L0:
+    r0 = builtins :: module
+    r1 = load_address _Py_NoneStruct
+    r2 = r0 != r1
+    if r2 goto L3 else goto L1 :: bool
+L1:
+    r3 = 'builtins'
+    r4 = PyImport_Import(r3)
+    if is_error(r4) goto L21 (error at <module>:-1) else goto L2
+L2:
+    builtins = r4 :: module
+    dec_ref r4
+L3:
+    r5 = ('Final',)
+    r6 = 'typing'
+    r7 = faster_eth_abi.packed.globals :: static
+    r8 = CPyImport_ImportFromMany(r6, r5, r5, r7)
+    if is_error(r8) goto L21 (error at <module>:1) else goto L4
+L4:
+    typing = r8 :: module
+    dec_ref r8
+    r9 = ('ABIEncoder',)
+    r10 = 'faster_eth_abi.codec'
+    r11 = faster_eth_abi.packed.globals :: static
+    r12 = CPyImport_ImportFromMany(r10, r9, r9, r11)
+    if is_error(r12) goto L21 (error at <module>:5) else goto L5
+L5:
+    faster_eth_abi.codec = r12 :: module
+    dec_ref r12
+    r13 = ('registry_packed',)
+    r14 = 'faster_eth_abi.registry'
+    r15 = faster_eth_abi.packed.globals :: static
+    r16 = CPyImport_ImportFromMany(r14, r13, r13, r15)
+    if is_error(r16) goto L21 (error at <module>:8) else goto L6
+L6:
+    faster_eth_abi.registry = r16 :: module
+    dec_ref r16
+    r17 = faster_eth_abi.packed.globals :: static
+    r18 = 'registry_packed'
+    r19 = CPyDict_GetItem(r17, r18)
+    if is_error(r19) goto L21 (error at <module>:12) else goto L7
+L7:
+    r20 = faster_eth_abi.packed.globals :: static
+    r21 = 'ABIEncoder'
+    r22 = CPyDict_GetItem(r20, r21)
+    if is_error(r22) goto L22 (error at <module>:12) else goto L8
+L8:
+    r23 = [r19]
+    r24 = load_address r23
+    r25 = PyObject_Vectorcall(r22, r24, 1, 0)
+    dec_ref r22
+    if is_error(r25) goto L22 (error at <module>:12) else goto L9
+L9:
+    dec_ref r19
+    faster_eth_abi.packed.default_encoder_packed = r25 :: static
+    r26 = faster_eth_abi.packed.globals :: static
+    r27 = 'default_encoder_packed'
+    r28 = CPyDict_SetItem(r26, r27, r25)
+    dec_ref r25
+    r29 = r28 >= 0 :: signed
+    if not r29 goto L21 (error at <module>:12) else goto L10 :: bool
+L10:
+    r30 = faster_eth_abi.packed.default_encoder_packed :: static
+    if is_error(r30) goto L11 else goto L13
+L11:
+    r31 = raise NameError('value for final name "default_encoder_packed" was not set')
+    if not r31 goto L21 (error at <module>:14) else goto L12 :: bool
+L12:
+    unreachable
+L13:
+    r32 = 'encode'
+    r33 = CPyObject_GetAttr(r30, r32)
+    if is_error(r33) goto L21 (error at <module>:14) else goto L14
+L14:
+    faster_eth_abi.packed.encode_packed = r33 :: static
+    r34 = faster_eth_abi.packed.globals :: static
+    r35 = 'encode_packed'
+    r36 = CPyDict_SetItem(r34, r35, r33)
+    dec_ref r33
+    r37 = r36 >= 0 :: signed
+    if not r37 goto L21 (error at <module>:14) else goto L15 :: bool
+L15:
+    r38 = faster_eth_abi.packed.default_encoder_packed :: static
+    if is_error(r38) goto L16 else goto L18
+L16:
+    r39 = raise NameError('value for final name "default_encoder_packed" was not set')
+    if not r39 goto L21 (error at <module>:15) else goto L17 :: bool
+L17:
+    unreachable
+L18:
+    r40 = 'is_encodable'
+    r41 = CPyObject_GetAttr(r38, r40)
+    if is_error(r41) goto L21 (error at <module>:15) else goto L19
+L19:
+    faster_eth_abi.packed.is_encodable_packed = r41 :: static
+    r42 = faster_eth_abi.packed.globals :: static
+    r43 = 'is_encodable_packed'
+    r44 = CPyDict_SetItem(r42, r43, r41)
+    dec_ref r41
+    r45 = r44 >= 0 :: signed
+    if not r45 goto L21 (error at <module>:15) else goto L20 :: bool
+L20:
+    return 1
+L21:
+    r46 = <error> :: None
+    return r46
+L22:
+    dec_ref r19
+    goto L21

--- a/faster_eth_abi/utils/numeric.py
+++ b/faster_eth_abi/utils/numeric.py
@@ -17,7 +17,8 @@ Decimal: Final = decimal.Decimal
 
 
 def ceil32(x: int) -> int:
-    return x if x % 32 == 0 else x + 32 - (x % 32)
+    remainder = x % 32
+    return x if remainder == 0 else x + 32 - (x % 32)
 
 
 _unsigned_integer_bounds_cache: Final[Dict[int, Tuple[int, int]]] = {}

--- a/faster_eth_abi/utils/numeric.py
+++ b/faster_eth_abi/utils/numeric.py
@@ -9,7 +9,6 @@ from typing import (
 ABI_DECIMAL_PREC: Final = 999
 
 abi_decimal_context: Final = decimal.Context(prec=ABI_DECIMAL_PREC)
-decimal_localcontext: Final = decimal.localcontext
 
 ZERO: Final = decimal.Decimal(0)
 TEN: Final = decimal.Decimal(10)
@@ -18,8 +17,7 @@ Decimal: Final = decimal.Decimal
 
 
 def ceil32(x: int) -> int:
-    remainder = x % 32
-    return x if remainder == 0 else x + 32 - (x % 32)
+    return x if x % 32 == 0 else x + 32 - (x % 32)
 
 
 _unsigned_integer_bounds_cache: Final[Dict[int, Tuple[int, int]]] = {}
@@ -39,10 +37,10 @@ _signed_integer_bounds_cache: Final[Dict[int, Tuple[int, int]]] = {}
 def compute_signed_integer_bounds(num_bits: int) -> Tuple[int, int]:
     bounds = _signed_integer_bounds_cache.get(num_bits)
     if bounds is None:
-        overflow_at = 2 ** (num_bits - 1)
-        min_value = -overflow_at
-        max_value = overflow_at - 1
-        bounds = min_value, max_value
+        bounds = (
+            -1 * 2 ** (num_bits - 1),
+            2 ** (num_bits - 1) - 1,
+        )
         _signed_integer_bounds_cache[num_bits] = bounds
     return bounds
 
@@ -56,17 +54,19 @@ def compute_unsigned_fixed_bounds(
 ) -> Tuple[decimal.Decimal, decimal.Decimal]:
     upper = _unsigned_fixed_bounds_cache.get((num_bits, frac_places))
     if upper is None:
-        int_upper = 2 ** (num_bits - 1) - 1
-    
-        with decimal_localcontext(abi_decimal_context):
+        int_upper = compute_unsigned_integer_bounds(num_bits)[1]
+
+        with decimal.localcontext(abi_decimal_context):
             upper = Decimal(int_upper) * TEN**-frac_places
 
         _unsigned_fixed_bounds_cache[(num_bits, frac_places)] = upper
-        
+
     return ZERO, upper
 
 
-_signed_fixed_bounds_cache: Final[Dict[Tuple[int, int], Tuple[decimal.Decimal, decimal.Decimal]]] = {}
+_signed_fixed_bounds_cache: Final[
+    Dict[Tuple[int, int], Tuple[decimal.Decimal, decimal.Decimal]]
+] = {}
 
 
 def compute_signed_fixed_bounds(
@@ -76,8 +76,8 @@ def compute_signed_fixed_bounds(
     bounds = _signed_fixed_bounds_cache.get((num_bits, frac_places))
     if bounds is None:
         int_lower, int_upper = compute_signed_integer_bounds(num_bits)
-    
-        with decimal_localcontext(abi_decimal_context):
+
+        with decimal.localcontext(abi_decimal_context):
             exp = TEN**-frac_places
             lower = Decimal(int_lower) * exp
             upper = Decimal(int_upper) * exp
@@ -99,11 +99,11 @@ def scale_places(places: int) -> Callable[[decimal.Decimal], decimal.Decimal]:
             f"of type {type(places)}.",
         )
 
-    with decimal_localcontext(abi_decimal_context):
+    with decimal.localcontext(abi_decimal_context):
         scaling_factor = TEN**-places
 
     def f(x: decimal.Decimal) -> decimal.Decimal:
-        with decimal_localcontext(abi_decimal_context):
+        with decimal.localcontext(abi_decimal_context):
             return x * scaling_factor
 
     places_repr = f"Eneg{places}" if places > 0 else f"Epos{-places}"


### PR DESCRIPTION
This reverts commit 553f0d4f5b2e061085ab10fcb557d0c910cc7508.

### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/faster-eth-abi/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
