### PR TITLE
[codex] Run benchmark workflow on requirements changes

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -9,6 +9,7 @@ on:
       - "benchmarks/**"
       - "setup.py"
       - "pyproject.toml"
+      - "requirements*.txt"
       - "!eth-abi-stubs/**"
   push:
     branches: [main, master]
@@ -18,6 +19,7 @@ on:
       - "benchmarks/**"
       - "setup.py"
       - "pyproject.toml"
+      - "requirements*.txt"
       - "!eth-abi-stubs/**"
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

Adds `requirements*.txt` to the `Benchmark Suite` workflow path filters for both pull requests and pushes.

## Why

PRs that only update benchmark dependencies currently do not queue the benchmark workflow. For example, #444 only changed `requirements-codspeed.txt`, so GitHub ran `Lint` and `Compile` but did not run `Benchmark Suite`.

## Validation

- Parsed `.github/workflows/benchmark.yaml` with PyYAML.
- Confirmed `requirements-codspeed.txt`, `requirements-benchmark.txt`, and `requirements-pytest.txt` match `requirements*.txt`.
- Confirmed the branch diff only modifies `.github/workflows/benchmark.yaml` with two added path-filter entries.