### PR TITLE
fix: declare license file in package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,6 +124,7 @@ setup(
     python_requires=">=3.10, <4",
     extras_require=extras_require,
     license="MIT",
+    license_files=["LICENSE"],
     zip_safe=False,
     keywords="ethereum",
     packages=find_packages(
@@ -143,7 +144,6 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
## Summary

Update package metadata to declare the bundled `LICENSE` file directly and remove the deprecated license classifier.

## Rationale

Setuptools now warns when projects rely on license classifiers instead of modern license metadata. The package already uses `license="MIT"` and includes `LICENSE`, so this PR makes that file explicit with `license_files=["LICENSE"]` and removes the deprecated `License :: OSI Approved :: MIT License` classifier.

## Details

- Add `license_files=["LICENSE"]` to `setup.py`.
- Remove the deprecated MIT license classifier.
- Leave the already-merged release workflow sparse-checkout cleanup out of this branch.
- Leave `_encoding.py` generator-comprehension cleanup out of scope because mypyc is expected to handle that automatically.
- Verified with `git diff --check`, `python3 -m build`, and `uvx twine check dist/*`.