### PR TITLE
fix(cicd): clean up release workflow warnings

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,6 +85,8 @@ jobs:
             setup.py
             pyproject.toml
             README.md
+            LICENSE
+            scripts/
             MANIFEST.in
             requirements.txt
             requirements-benchmark.txt
@@ -117,8 +119,6 @@ jobs:
 
       - name: Build wheels
         env:
-          # Skip PyPy
-          CIBW_SKIP: pp*
           # On Linux: manylinux / musllinux arches
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux || '' }}
           # On Windows: AMD64 / x86
@@ -149,6 +149,8 @@ jobs:
             setup.py
             pyproject.toml
             README.md
+            LICENSE
+            scripts/
             MANIFEST.in
             requirements.txt
             requirements-benchmark.txt


### PR DESCRIPTION
## Summary

Clean up actionable release workflow warnings by aligning sparse-checkout inputs with packaged files and removing a stale cibuildwheel skip selector.

## Rationale

The release workflow sparse checkout omitted files that `MANIFEST.in` intentionally includes, producing packaging warnings for `LICENSE` and `scripts/`. The workflow also set `CIBW_SKIP: pp*`, but cibuildwheel 4 does not build PyPy by default, so that selector no longer has an effect and produces release-log noise.

## Details

- Add `LICENSE` and `scripts/` to both release sparse-checkout blocks.
- Remove the stale `CIBW_SKIP: pp*` environment entry.
- Leave packaging metadata, source code, and mypyc/compiler warnings out of scope for this workflow-only PR.
- Verified with `git diff --check`, `python3 -m build`, and `uvx twine check dist/*`.