### PR TITLE
fix(cicd): build Windows x86 wheels with x86 Python

### DIFF
--- a/.github/mypycify-hash/x86.txt
+++ b/.github/mypycify-hash/x86.txt
@@ -1,1 +1,2 @@
 marker for matrix architecture x86
+windows x86 wheel builds must use the selected x86 Python interpreter

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -92,6 +92,7 @@ jobs:
 
       # All other builds (64-bit Linux, 32-bit and 64-bit Windows)
       - name: Set up Python
+        id: setup_python
         if: ${{ matrix.os != 'macos-latest' && env.IS_UBUNTU_32BIT != 'true' }}
         uses: actions/setup-python@v6
         with:
@@ -119,6 +120,12 @@ jobs:
             pyproject.toml
             setup.py
             tox.ini
+          build-command: >-
+            ${{
+              matrix.os == 'windows-latest' && matrix.architecture == 'x86'
+              && format('''{0}'' -m pip install --upgrade pip build && ''{0}'' -m build --wheel', steps.setup_python.outputs.python-path)
+              || 'python -m build --wheel'
+            }}
 
       - name: Determine wheel artifact architecture
         if: ${{ env.IS_UBUNTU_32BIT != 'true' }}
@@ -132,6 +139,23 @@ jobs:
         with:
           name: BobTheBuidler_mypycified_wheel-${{ runner.os }}-${{ steps.artifact_arch.outputs.value }}-py3.${{ matrix.pyminor }}-${{ matrix.installmode }}-${{ hashFiles('faster_eth_abi/**/*.py', 'pyproject.toml', 'setup.py', format('.github/mypycify-hash/{0}.txt', matrix.architecture)) }}
           path: dist
+
+      - name: Validate Windows x86 wheel tag
+        if: ${{ matrix.os == 'windows-latest' && matrix.architecture == 'x86' }}
+        shell: bash
+        run: |
+          shopt -s nullglob
+          wheels=(dist/*.whl)
+          if [[ "${#wheels[@]}" -ne 1 ]]; then
+            echo "Expected exactly one wheel in dist, found ${#wheels[@]}"
+            printf '%s\n' "${wheels[@]}"
+            exit 1
+          fi
+          wheel="${wheels[0]}"
+          if [[ "$wheel" != *-win32.whl ]]; then
+            echo "Expected Windows x86 wheel tagged win32, got: $wheel"
+            exit 1
+          fi
 
       - name: Upgrade pip and install tox
         if: ${{ env.IS_UBUNTU_32BIT != 'true' }}


### PR DESCRIPTION
## Summary

- Force Windows x86 wheel builds to use the matrix-selected x86 Python interpreter.
- Add a Windows x86 sanity check that rejects non-`win32` wheel artifacts.
- Bust the x86 mypycify cache marker to avoid reusing stale `win_amd64` artifacts.

## Rationale

Windows x86 CI selected x86 Python before invoking `BobTheBuidler/mypycify`, but the composite action runs its own `setup-python` without an architecture input. That defaults back to the host architecture on Windows, which can build or restore `win_amd64` wheels for x86 jobs.

Those wheels are correctly rejected by pip as unsupported on 32-bit Python. The fix keeps Windows x86 compiled-wheel validation intact by forcing the build command through the x86 interpreter captured from the matrix setup step.

## Details

- Adds an `id` to the non-macOS `setup-python` step so the workflow can use `steps.setup_python.outputs.python-path`.
- Passes a Windows x86-only `build-command` override to `mypycify@v0.4.1`.
- Keeps the default `python -m build --wheel` path for every other matrix job.
- Verifies Windows x86 downloaded artifacts are tagged `win32` before tox runs.
- Updates `.github/mypycify-hash/x86.txt` to invalidate stale x86 wheel caches.

## Testing

- `git diff --check`
- `tox c -e windows-wheel`
- `tox c -e py312-wheel`

Full Windows x86 wheel validation must run in GitHub Actions.