### PR TITLE
refactor(cicd): unify wheel tox environments

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -43,7 +43,7 @@ jobs:
       max-parallel: ${{ github.event_name == 'schedule' && 4 || 1000 }}
     env:
       IS_UBUNTU_32BIT: ${{ matrix.os == 'ubuntu-latest' && matrix.architecture == 'x86' }}
-      TOXENV: ${{ matrix.os == 'windows-latest' && matrix.jobtype == 'wheel' && 'windows-wheel' || format('py3{0}-{1}', matrix.pyminor, matrix.jobtype) }}
+      TOXENV: py3${{ matrix.pyminor }}-${{ matrix.jobtype }}
       TOX_RECREATE_FLAG: ${{ github.event_name == 'schedule' && '-r' || '' }}
 
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist=
     py{310,311,312,313,313t,314,314t}-core
     py{310,311,312,313,313t,314,314t}-lint
     py{310,311,312,313,313t,314,314t}-wheel
-    windows-wheel
     docs
 
 [flake8]
@@ -22,7 +21,6 @@ commands=
     docs: make check-docs-ci
 basepython=
     docs: python
-    windows-wheel: python
 extras=
     test
     docs
@@ -40,18 +38,6 @@ pass_env=
     WHEEL_PATH
 commands=
     python -c "import os; assert os.environ.get('WHEEL_PATH'), 'WHEEL_PATH must point to the built wheel artifact'"
-    python -m pip install --upgrade pip
-    python -m pip install --upgrade {env:WHEEL_PATH:} --progress-bar off
-    python -c "import faster_eth_abi"
-    python -c "import importlib.machinery as m; import faster_eth_abi.abi as abi; assert any(abi.__file__.endswith(s) for s in m.EXTENSION_SUFFIXES), abi.__file__"
-skip_install=true
-
-[testenv:windows-wheel]
-pass_env=
-    WHEEL_PATH
-commands=
-    python -c "import os; assert os.environ.get('WHEEL_PATH'), 'WHEEL_PATH must point to the built wheel artifact'"
-    python --version
     python -m pip install --upgrade pip
     python -m pip install --upgrade {env:WHEEL_PATH:} --progress-bar off
     python -c "import faster_eth_abi"


### PR DESCRIPTION
## Summary

- Remove the redundant Windows-only wheel tox environment.
- Use the generic `py3xx-wheel` tox env for Windows wheel validation too.
- Keep the follow-up scoped to CI simplification only.

## Rationale

The previous Windows-specific wheel env existed for shell-specific wheel validation behavior. After the wheel validation flow was changed to install the supplied `WHEEL_PATH` artifact directly, the Windows-only env no longer provides distinct behavior.

Keeping a separate `windows-wheel` env now adds extra CI surface without changing what is validated.

## Details

- Simplifies the workflow `TOXENV` selection to always use `py3${{ matrix.pyminor }}-${{ matrix.jobtype }}`.
- Removes `windows-wheel` from `tox.ini`.
- Removes the duplicated `[testenv:windows-wheel]` configuration.
- Leaves production code, package metadata, and test behavior unchanged.

## Testing

- `git diff --check origin/master..refactor/unify-wheel-tox-envs`
- `tox c -e py312-wheel`

Full Windows matrix validation should run in GitHub Actions.