### PR TITLE
fix(cicd): restore Windows x86 Python before tox

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -127,6 +127,17 @@ jobs:
               || 'python -m build --wheel'
             }}
 
+      - name: Restore Windows x86 Python
+        if: ${{ matrix.os == 'windows-latest' && matrix.architecture == 'x86' }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.${{ matrix.pyminor }}
+          architecture: ${{ matrix.architecture }}
+
+      - name: Validate Windows x86 Python
+        if: ${{ matrix.os == 'windows-latest' && matrix.architecture == 'x86' }}
+        run: python -c "import struct; bits = struct.calcsize('P') * 8; assert bits == 32, bits"
+
       - name: Determine wheel artifact architecture
         if: ${{ env.IS_UBUNTU_32BIT != 'true' }}
         id: artifact_arch


### PR DESCRIPTION
## Summary

- Re-select Windows x86 Python after `mypycify` runs.
- Add a Windows x86 pointer-width sanity check before artifact validation and tox.
- Keep the change scoped to CI workflow interpreter selection.

## Rationale

`BobTheBuidler/mypycify@v0.4.1` runs its own architecture-less `actions/setup-python`, which can put host x64 Python back on `PATH` during Windows x86 jobs.

The previous fix forced the wheel build to use the captured x86 interpreter, but later workflow steps still used bare `python`. That could make tox run under x64 Python while installing a `win32` wheel.

## Details

- Adds a Windows x86-only `actions/setup-python@v6` step immediately after `mypycify`.
- Uses `python-version: 3.${{ matrix.pyminor }}` and `architecture: ${{ matrix.architecture }}`.
- Adds a sanity check that asserts the active Python pointer size is 32-bit before continuing.
- Leaves production code, package metadata, and tox behavior unchanged.

## Testing

- `git diff --check origin/master..fix/windows-x86-restore-python`
- `/tmp/faster-eth-abi-tox-venv/bin/python -m tox c -e py312-wheel`

Full Windows x86 validation must run in GitHub Actions.