### PR TITLE
fix(cicd): use mypycify Python architecture input

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -92,7 +92,6 @@ jobs:
 
       # All other builds (64-bit Linux, 32-bit and 64-bit Windows)
       - name: Set up Python
-        id: setup_python
         if: ${{ matrix.os != 'macos-latest' && env.IS_UBUNTU_32BIT != 'true' }}
         uses: actions/setup-python@v6
         with:
@@ -107,9 +106,10 @@ jobs:
       - name: Build wheel with mypycify
         if: ${{ env.IS_UBUNTU_32BIT != 'true' }}
         id: mypycify
-        uses: BobTheBuidler/mypycify@v0.4.1
+        uses: BobTheBuidler/mypycify@v0.5.0
         with:
           python-version: 3.${{ matrix.pyminor }}
+          python-architecture: ${{ matrix.os == 'windows-latest' && matrix.architecture == 'x86' && matrix.architecture || '' }}
           hash-key: |
             faster_eth_abi/**/*.py
             pyproject.toml
@@ -120,35 +120,12 @@ jobs:
             pyproject.toml
             setup.py
             tox.ini
-          build-command: >-
-            ${{
-              matrix.os == 'windows-latest' && matrix.architecture == 'x86'
-              && format('''{0}'' -m pip install --upgrade pip build && ''{0}'' -m build --wheel', steps.setup_python.outputs.python-path)
-              || 'python -m build --wheel'
-            }}
-
-      - name: Restore Windows x86 Python
-        if: ${{ matrix.os == 'windows-latest' && matrix.architecture == 'x86' }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.${{ matrix.pyminor }}
-          architecture: ${{ matrix.architecture }}
-
-      - name: Validate Windows x86 Python
-        if: ${{ matrix.os == 'windows-latest' && matrix.architecture == 'x86' }}
-        run: python -c "import struct; bits = struct.calcsize('P') * 8; assert bits == 32, bits"
-
-      - name: Determine wheel artifact architecture
-        if: ${{ env.IS_UBUNTU_32BIT != 'true' }}
-        id: artifact_arch
-        shell: bash
-        run: echo "value=$(uname -m)" >> "$GITHUB_OUTPUT"
 
       - name: Download built wheel artifact
         if: ${{ env.IS_UBUNTU_32BIT != 'true' }}
         uses: actions/download-artifact@v8
         with:
-          name: BobTheBuidler_mypycified_wheel-${{ runner.os }}-${{ steps.artifact_arch.outputs.value }}-py3.${{ matrix.pyminor }}-${{ matrix.installmode }}-${{ hashFiles('faster_eth_abi/**/*.py', 'pyproject.toml', 'setup.py', format('.github/mypycify-hash/{0}.txt', matrix.architecture)) }}
+          name: ${{ steps.mypycify.outputs.artifact-name }}
           path: dist
 
       - name: Validate Windows x86 wheel tag


### PR DESCRIPTION
## Summary

- Update wheel CI to use `BobTheBuidler/mypycify@v0.5.0`.
- Pass `python-architecture: x86` for Windows x86 jobs.
- Download the wheel artifact through `steps.mypycify.outputs.artifact-name`.

## Rationale

Once `mypycify` owns Python architecture selection, faster-eth-abi no longer needs custom build-command workarounds or local artifact-name reconstruction.

## Details

- Removes the Windows x86 custom `build-command`.
- Removes local `uname -m` artifact architecture detection.
- Uses the action-owned artifact name output.
- Preserves default behavior for all non-Windows-x86 jobs.

## Testing

- `git diff --check origin/master..HEAD`
- Parsed `.github/workflows/tox.yaml` with PyYAML.
- `/tmp/faster-eth-abi-tox-venv/bin/python -m tox c -e py312-wheel`

Full Windows x86 validation must run in GitHub Actions.

## Dependency

Requires `BobTheBuidler/mypycify@v0.5.0` to exist before this PR can pass CI.